### PR TITLE
Streamline the terminology around core data structures

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -213,14 +213,14 @@ final class Symtab {
 }
 ```
 
-Scopes are collections of symbols that support entering symbols under simple ids
-and looking up symbols using simple ids. Following the language specification,
-such a simple id can be either a `TermSid` or a `TypeSid`.
+Scopes are collections of symbols that support entering symbols under simple names
+and looking up symbols using simple names. Following the language specification,
+such a simple name can be either a `TermName` or a `TypeName`.
 
 ```scala
 sealed abstract class Scope(val sym: Symbol) {
-  def enter(sid: Sid, sym: Symbol): Symbol
-  def lookup(sid: Sid): Symbol
+  def enter(name: Name, sym: Symbol): Symbol
+  def lookup(name: Name): Symbol
   ...
 }
 ```
@@ -240,7 +240,7 @@ sealed abstract class Scope(val sym: Symbol) {
 
   var status: Status = PendingStatus
 
-  def resolve(sid: Sid): Resolution = {
+  def resolve(name: Name): Resolution = {
     status match {
       case PendingStatus =>
         BlockedResolution(this)

--- a/rsc/src/main/scala/rsc/parse/Lits.scala
+++ b/rsc/src/main/scala/rsc/parse/Lits.scala
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.parse
 
+import scala.{Symbol => StdlibSymbol}
 import rsc.lexis._
 import rsc.report._
 
@@ -29,7 +30,7 @@ trait Lits {
       case NULL =>
         null
       case LITSYMBOL =>
-        in.value.asInstanceOf[Symbol]
+        in.value.asInstanceOf[StdlibSymbol]
       case _ =>
         reportOffset(in.offset, IllegalLiteral)
         null

--- a/rsc/src/main/scala/rsc/pretty/PrettyName.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyName.scala
@@ -4,19 +4,19 @@ package rsc.pretty
 
 import rsc.semantics._
 
-object PrettySid {
-  def str(p: Printer, x: Sid): Unit = {
+object PrettyName {
+  def str(p: Printer, x: Name): Unit = {
     x match {
-      case SomeSid(value) =>
+      case SomeName(value) =>
         p.str(value)
-      case TermSid(value) =>
+      case TermName(value) =>
         p.str(value + ".")
-      case TypeSid(value) =>
+      case TypeName(value) =>
         p.str(value + "#")
     }
   }
 
-  def repl(p: Printer, x: Sid): Unit = {
+  def repl(p: Printer, x: Name): Unit = {
     new ProductRepl(p).apply(x)
   }
 }

--- a/rsc/src/main/scala/rsc/pretty/PrettyResolution.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyResolution.scala
@@ -9,13 +9,13 @@ object PrettyResolution {
     x match {
       case BlockedResolution(scope) =>
         p.str("b:")
-        p.str(scope.uid)
+        p.str(scope.sym)
       case MissingResolution =>
         p.str("m")
       case ErrorResolution =>
         p.str("e")
-      case FoundResolution(uid) =>
-        p.str(uid)
+      case FoundResolution(sym) =>
+        p.str(sym)
     }
   }
 

--- a/rsc/src/main/scala/rsc/pretty/PrettyScope.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyScope.scala
@@ -8,20 +8,20 @@ import rsc.util._
 
 object PrettyScope {
   def str(p: Printer, x: Scope): Unit = {
-    p.str(x.uid)
+    p.str(x.sym)
     p.str(" ")
     p.str(x.status)
     if (x.status.isSucceeded) {
       x match {
         case x: ImporterScope =>
           p.str(" ")
-          p.str(x.parent.uid)
+          p.str(x.parent.sym)
         case x: TemplateScope =>
           p.str(" ")
-          p.rep(x.parents, " with ")(scope => p.str(scope.uid))
+          p.rep(x.parents, " with ")(scope => p.str(scope.sym))
         case x: SuperScope =>
           p.str(" ")
-          p.rep(x.underlying.parents, " with ")(scope => p.str(scope.uid))
+          p.rep(x.underlying.parents, " with ")(scope => p.str(scope.sym))
         case _ =>
           ()
       }

--- a/rsc/src/main/scala/rsc/pretty/PrettyStatus.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyStatus.scala
@@ -11,10 +11,10 @@ object PrettyStatus {
         p.str("?")
       case BlockedStatus(scope) =>
         p.str("b:")
-        p.str(scope.uid)
+        p.str(scope.sym)
       case CyclicStatus(scopes) =>
         p.str("c:")
-        p.str(scopes.map(_.uid))
+        p.str(scopes.map(_.sym))
       case ErrorStatus =>
         p.str("e")
       case SucceededStatus =>

--- a/rsc/src/main/scala/rsc/pretty/PrettySymtab.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySymtab.scala
@@ -21,8 +21,8 @@ object PrettySymtab {
     p.header("Outlines (symtab)")
     val outlines = x._outlines.asScala.toList.sortBy(_._1.str)
     p.rep(outlines, EOL) {
-      case (uid, outline) =>
-        p.str(uid)
+      case (sym, outline) =>
+        p.str(sym)
         p.str(" => ")
         p.str(outline)
     }

--- a/rsc/src/main/scala/rsc/pretty/PrettyType.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyType.scala
@@ -9,8 +9,8 @@ object PrettyType {
     tpe match {
       case NoType =>
         p.str("ø")
-      case SimpleType(uid, targs) =>
-        p.str("<" + uid + ">")
+      case SimpleType(sym, targs) =>
+        p.str("<" + sym + ">")
         if (targs.nonEmpty) {
           p.str("[")
           p.rep(targs, ", ")(p.str)
@@ -19,12 +19,12 @@ object PrettyType {
       case MethodType(tparams, vparamss, ret) =>
         if (tparams.nonEmpty) {
           p.str("[")
-          p.rep(tparams, ", ")(uid => p.str("<" + uid + ">"))
+          p.rep(tparams, ", ")(sym => p.str("<" + sym + ">"))
           p.str("]")
         }
         vparamss.foreach { vparams =>
           p.str("(")
-          p.rep(vparams, ", ")(uid => p.str("<" + uid + ">"))
+          p.rep(vparams, ", ")(sym => p.str("<" + sym + ">"))
           p.str(")")
         }
         p.str(":")

--- a/rsc/src/main/scala/rsc/pretty/Repl.scala
+++ b/rsc/src/main/scala/rsc/pretty/Repl.scala
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.pretty
 
+import scala.{Symbol => StdlibSymbol}
 import rsc.util._
 
 trait Repl[T] {
@@ -69,7 +70,7 @@ object Repl {
     else p.str("null")
   }
 
-  implicit def symbol[T <: Symbol]: Repl[T] = Repl { (p, x) =>
+  implicit def stdlibSymbol[T <: StdlibSymbol]: Repl[T] = Repl { (p, x) =>
     if (x != null) {
       p.str("'")
       p.str(x.toString)

--- a/rsc/src/main/scala/rsc/pretty/Str.scala
+++ b/rsc/src/main/scala/rsc/pretty/Str.scala
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.pretty
 
+import scala.{Symbol => StdlibSymbol}
 import rsc.util._
 
 trait Str[T] {
@@ -59,7 +60,7 @@ object Str {
     else p.str("null")
   }
 
-  implicit def symbol[T <: Symbol]: Repl[T] = Repl { (p, x) =>
+  implicit def stdlibSymbol[T <: StdlibSymbol]: Repl[T] = Repl { (p, x) =>
     if (x != null) {
       p.str("'")
       p.str(x.toString)

--- a/rsc/src/main/scala/rsc/pretty/TreeStr.scala
+++ b/rsc/src/main/scala/rsc/pretty/TreeStr.scala
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.pretty
 
+import scala.{Symbol => StdlibSymbol}
 import rsc.semantics._
 import rsc.syntax._
 import rsc.util._
@@ -222,7 +223,7 @@ class TreeStr(val p: Printer) {
         p.repl(false)
       case TermLit(null) =>
         p.repl(null)
-      case TermLit(value: Symbol) =>
+      case TermLit(value: StdlibSymbol) =>
         p.repl(value)
       case TermLit(other) =>
         crash(other.getClass.toString)

--- a/rsc/src/main/scala/rsc/pretty/TreeStr.scala
+++ b/rsc/src/main/scala/rsc/pretty/TreeStr.scala
@@ -113,7 +113,7 @@ class TreeStr(val p: Printer) {
       case ModVar() =>
         p.str("var")
       case x @ NamedId(value) =>
-        if (x.uid != NoUid) p.str("<" + x.uid + ">")
+        if (x.sym != NoSymbol) p.str("<" + x.sym + ">")
         else p.str(value)
       case PatAlternative(pats) =>
         apply(pats, " | ")
@@ -150,7 +150,7 @@ class TreeStr(val p: Printer) {
           p.str(" ")
           p.Suffix(" ")(mods)(apply(_, " "))
         }
-        if (tree.id.uid != NoUid) p.str("<" + tree.id.uid + ">")
+        if (tree.id.sym != NoSymbol) p.str("<" + tree.id.sym + ">")
         else ()
         p.Parens(apply(params, ", "))
       case Source(stats) =>

--- a/rsc/src/main/scala/rsc/report/Messages.scala
+++ b/rsc/src/main/scala/rsc/report/Messages.scala
@@ -262,11 +262,11 @@ final case class NonValue(term: Term, tpe: Type) extends Message {
   def text = s"not a value: $tpe"
 }
 
-final case class UnboundMember(qualUid: Uid, id: Id) extends Message {
+final case class UnboundMember(qualSym: Symbol, id: Id) extends Message {
   def sev = ErrorSeverity
   def pos = id.point
   def text = {
-    val qualDesc = qualUid
+    val qualDesc = qualSym
     id match {
       case AnonId() => crash(id)
       case CtorId() => crash(id)

--- a/rsc/src/main/scala/rsc/scan/Scanner.scala
+++ b/rsc/src/main/scala/rsc/scan/Scanner.scala
@@ -3,6 +3,7 @@
 package rsc.scan
 
 import scala.annotation.switch
+import scala.{Symbol => StdlibSymbol}
 import rsc.lexis._
 import rsc.report._
 import rsc.settings._
@@ -134,11 +135,11 @@ final class Scanner private (
     if (isAlphanumericIdStart(ch) && ch1 != '\'') {
       alphanumericIdOrKeyword()
       token = LITSYMBOL
-      value = Symbol(value.asInstanceOf[String].stripPrefix("'"))
+      value = StdlibSymbol(value.asInstanceOf[String].stripPrefix("'"))
     } else if (isSymbolicIdStart(ch) && ch != '\\' && ch1 != '\'') {
       symbolicIdOrKeyword()
       token = LITSYMBOL
-      value = Symbol(value.asInstanceOf[String].stripPrefix("'"))
+      value = StdlibSymbol(value.asInstanceOf[String].stripPrefix("'"))
     } else {
       val result = quote('\'')
       if (ch == '\'') {

--- a/rsc/src/main/scala/rsc/semantics/Envs.scala
+++ b/rsc/src/main/scala/rsc/semantics/Envs.scala
@@ -29,11 +29,11 @@ sealed class Env protected (val _scopes: List[Scope]) extends Pretty {
     Env(scope :: _scopes)
   }
 
-  def lookup(sid: Sid): Symbol = {
+  def lookup(name: Name): Symbol = {
     @tailrec def loop(_scopes: List[Scope]): Symbol = {
       _scopes match {
         case head :: tail =>
-          head.lookup(sid) match {
+          head.lookup(name) match {
             case NoSymbol => loop(tail)
             case other => other
           }
@@ -44,14 +44,14 @@ sealed class Env protected (val _scopes: List[Scope]) extends Pretty {
     loop(_scopes)
   }
 
-  def lookupThis(qual: Option[Sid]): Symbol = {
+  def lookupThis(qual: Option[Name]): Symbol = {
     @tailrec def loop(_scopes: List[Scope]): Symbol = {
       _scopes match {
         case (head: TemplateScope) :: tail =>
           val found = {
             qual match {
-              case Some(SomeSid(value)) => head.tree.id.value == value
-              case Some(sid) => head.tree.id.sid == sid
+              case Some(SomeName(value)) => head.tree.id.value == value
+              case Some(name) => head.tree.id.name == name
               case None => true
             }
           }
@@ -66,7 +66,7 @@ sealed class Env protected (val _scopes: List[Scope]) extends Pretty {
     loop(_scopes)
   }
 
-  def lookupSuper(mix: Option[Sid]): Symbol = {
+  def lookupSuper(mix: Option[Name]): Symbol = {
     _scopes match {
       case List(thisScope: TemplateScope) =>
         mix match {
@@ -76,8 +76,8 @@ sealed class Env protected (val _scopes: List[Scope]) extends Pretty {
                 case head :: tail =>
                   val found = {
                     mix match {
-                      case SomeSid(value) => head.tree.id.value == value
-                      case sid => head.tree.id.sid == sid
+                      case SomeName(value) => head.tree.id.value == value
+                      case name => head.tree.id.name == name
                     }
                   }
                   if (found) head.sym
@@ -98,11 +98,11 @@ sealed class Env protected (val _scopes: List[Scope]) extends Pretty {
     }
   }
 
-  def resolve(sid: Sid): Resolution = {
+  def resolve(name: Name): Resolution = {
     @tailrec def loop(_scopes: List[Scope]): Resolution = {
       _scopes match {
         case head :: tail =>
-          head.resolve(sid) match {
+          head.resolve(name) match {
             case MissingResolution => loop(tail)
             case other => other
           }
@@ -113,14 +113,14 @@ sealed class Env protected (val _scopes: List[Scope]) extends Pretty {
     loop(_scopes)
   }
 
-  def resolveThis(qual: Option[Sid]): Resolution = {
+  def resolveThis(qual: Option[Name]): Resolution = {
     lookupThis(qual) match {
       case NoSymbol => MissingResolution
       case sym => FoundResolution(sym)
     }
   }
 
-  def resolveSuper(mix: Option[Sid]): Resolution = {
+  def resolveSuper(mix: Option[Name]): Resolution = {
     _scopes match {
       case List(thisScope: TemplateScope) =>
         thisScope.status match {

--- a/rsc/src/main/scala/rsc/semantics/Names.scala
+++ b/rsc/src/main/scala/rsc/semantics/Names.scala
@@ -4,23 +4,23 @@ package rsc.semantics
 
 import rsc.pretty._
 
-sealed trait Sid extends Pretty with Product {
+sealed trait Name extends Pretty with Product {
   def value: String
-  def printStr(p: Printer): Unit = PrettySid.str(p, this)
-  def printRepl(p: Printer): Unit = PrettySid.repl(p, this)
+  def printStr(p: Printer): Unit = PrettyName.str(p, this)
+  def printRepl(p: Printer): Unit = PrettyName.repl(p, this)
 }
 
-final case class SomeSid(value: String) extends Sid {
+final case class SomeName(value: String) extends Name {
   override val hashCode: Int = value.hashCode * 3
   override def str: String = value
 }
 
-final case class TermSid(value: String) extends Sid {
+final case class TermName(value: String) extends Name {
   override val hashCode: Int = value.hashCode * 5
   override def str: String = value + "."
 }
 
-final case class TypeSid(value: String) extends Sid {
+final case class TypeName(value: String) extends Name {
   override val hashCode: Int = value.hashCode * 7
   override def str: String = value + "#"
 }

--- a/rsc/src/main/scala/rsc/semantics/Resolutions.scala
+++ b/rsc/src/main/scala/rsc/semantics/Resolutions.scala
@@ -13,4 +13,4 @@ final case class BlockedResolution(scope: Scope) extends Resolution
 sealed trait FailedResolution extends Resolution
 final case object MissingResolution extends FailedResolution
 final case object ErrorResolution extends FailedResolution
-final case class FoundResolution(uid: Uid) extends Resolution
+final case class FoundResolution(sym: Symbol) extends Resolution

--- a/rsc/src/main/scala/rsc/semantics/Symbols.scala
+++ b/rsc/src/main/scala/rsc/semantics/Symbols.scala
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.semantics
 
-trait Uids {
-  type Uid = String
-  val NoUid: Uid = ""
+trait Symbols {
+  type Symbol = String
+  val NoSymbol: Symbol = ""
 
   private var counter = 0
-  def freshUid(): Uid = {
+  def freshSym(): Symbol = {
     counter += 1
     counter.toString
   }

--- a/rsc/src/main/scala/rsc/semantics/Symtab.scala
+++ b/rsc/src/main/scala/rsc/semantics/Symtab.scala
@@ -8,45 +8,45 @@ import rsc.syntax._
 import rsc.util._
 
 final class Symtab private extends Pretty {
-  val _scopes: Map[Uid, Scope] = new HashMap[Uid, Scope]
-  val _outlines: Map[Uid, Outline] = new HashMap[Uid, Outline]
+  val _scopes: Map[Symbol, Scope] = new HashMap[Symbol, Scope]
+  val _outlines: Map[Symbol, Outline] = new HashMap[Symbol, Outline]
 
   object scopes {
-    def apply(uid: Uid): Scope = {
-      val scope = _scopes.get(uid)
+    def apply(sym: Symbol): Scope = {
+      val scope = _scopes.get(sym)
       if (scope == null) {
-        crash(uid)
+        crash(sym)
       }
       scope
     }
 
-    def update(uid: Uid, scope: Scope): Unit = {
-      if (_scopes.containsKey(uid)) {
-        crash(uid)
+    def update(sym: Symbol, scope: Scope): Unit = {
+      if (_scopes.containsKey(sym)) {
+        crash(sym)
       }
-      uid match {
-        case NoUid => crash(scope)
+      sym match {
+        case NoSymbol => crash(scope)
         case other => _scopes.put(other, scope)
       }
     }
   }
 
   object outlines {
-    def apply(uid: Uid): Outline = {
-      val outline = _outlines.get(uid)
+    def apply(sym: Symbol): Outline = {
+      val outline = _outlines.get(sym)
       if (outline == null) {
-        crash(uid)
+        crash(sym)
       }
       outline
     }
 
-    def update(uid: Uid, outline: Outline): Unit = {
-      if (_outlines.containsKey(uid)) {
-        crash(uid)
+    def update(sym: Symbol, outline: Outline): Unit = {
+      if (_outlines.containsKey(sym)) {
+        crash(sym)
       }
-      uid match {
-        case NoUid => crash(outline)
-        case other => _outlines.put(uid, outline)
+      sym match {
+        case NoSymbol => crash(outline)
+        case other => _outlines.put(sym, outline)
       }
     }
   }

--- a/rsc/src/main/scala/rsc/semantics/Types.scala
+++ b/rsc/src/main/scala/rsc/semantics/Types.scala
@@ -11,10 +11,10 @@ sealed trait Type extends Pretty with Product {
 
 final case object NoType extends Type
 
-final case class SimpleType(uid: Uid, targs: List[SimpleType]) extends Type
+final case class SimpleType(sym: Symbol, targs: List[SimpleType]) extends Type
 
 final case class MethodType(
-    tparams: List[Uid],
-    params: List[Uid],
+    tparams: List[Symbol],
+    params: List[Symbol],
     ret: SimpleType)
     extends Type

--- a/rsc/src/main/scala/rsc/semantics/package.scala
+++ b/rsc/src/main/scala/rsc/semantics/package.scala
@@ -2,4 +2,4 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc
 
-package object semantics extends Uids
+package object semantics extends Symbols

--- a/rsc/src/main/scala/rsc/syntax/Trees.scala
+++ b/rsc/src/main/scala/rsc/syntax/Trees.scala
@@ -117,9 +117,9 @@ object Error {
 }
 
 sealed trait Id extends Tree {
-  var uid: Uid = NoUid
-  def withUid(uid: Uid): this.type = {
-    this.uid = uid
+  var sym: Symbol = NoSymbol
+  def withSym(sym: Symbol): this.type = {
+    this.sym = sym
     this
   }
 }
@@ -315,8 +315,8 @@ object TptApply {
 final case class TptFunction(targs: List[Tpt]) extends TptApply {
   def fun = {
     val value = "Function" + (targs.length - 1)
-    val uid = "_root_.scala." + value + "#"
-    TptId(value).withUid(uid)
+    val sym = "_root_.scala." + value + "#"
+    TptId(value).withSym(sym)
   }
 }
 
@@ -335,7 +335,7 @@ final case class TptParameterizeInfix(lhs: Tpt, op: TptId, rhs: Tpt)
 }
 
 final case class TptRepeat(targ: Tpt) extends Tpt with TptApply {
-  def fun = TptId("Seq").withUid("_root_.scala.Seq#")
+  def fun = TptId("Seq").withSym("_root_.scala.Seq#")
   def targs = List(targ)
 }
 
@@ -344,8 +344,8 @@ final case class TptSelect(qual: TermPath, id: TptId) extends TptPath
 final case class TptTuple(targs: List[Tpt]) extends TptApply {
   def fun = {
     val value = "Tuple" + targs.length
-    val uid = "_root_.scala." + value + "#"
-    TptId(value).withUid(uid)
+    val sym = "_root_.scala." + value + "#"
+    TptId(value).withSym(sym)
   }
 }
 
@@ -358,6 +358,6 @@ final case class TypeParam(
     lbound: Option[Tpt])
     extends Tree
     with Outline {
-  def hi = ubound.getOrElse(TptId("Any").withUid("_root_.scala.Any#"))
-  def lo = lbound.getOrElse(TptId("Nothing").withUid("_root_.scala.Nothing#"))
+  def hi = ubound.getOrElse(TptId("Any").withSym("_root_.scala.Any#"))
+  def lo = lbound.getOrElse(TptId("Nothing").withSym("_root_.scala.Nothing#"))
 }

--- a/rsc/src/main/scala/rsc/syntax/Trees.scala
+++ b/rsc/src/main/scala/rsc/syntax/Trees.scala
@@ -21,12 +21,12 @@ final case class Case(pat: Pat, cond: Option[Term], stats: List[Stat])
 
 final case class CtorId() extends NamedId {
   def value = CtorId.value
-  def sid = CtorId.sid
+  def name = CtorId.name
 }
 
 object CtorId {
   val value = "this"
-  val sid = TermSid("<init>")
+  val name = TermName("<init>")
 }
 
 final case class DefnClass(
@@ -172,7 +172,7 @@ final case class ModVar() extends Mod
 sealed trait NamedId extends Id with Path {
   def id = this
   def value: String
-  def sid: Sid
+  def name: Name
 }
 
 object NamedId {
@@ -196,7 +196,7 @@ final case class PatExtractInfix(lhs: Pat, op: TermId, rhs: List[Pat])
     extends Pat
 
 final case class PatId(value: String) extends Pat with NamedId {
-  def sid = TermSid(value)
+  def name = TermName(value)
 }
 
 final case class PatLit(value: Any) extends Pat
@@ -222,7 +222,7 @@ final case class PrimaryCtor(mods: List[Mod], params: List[TermParam])
 }
 
 final case class SomeId(value: String) extends NamedId {
-  def sid = SomeSid(value)
+  def name = SomeName(value)
 }
 
 final case class Source(stats: List[Stat]) extends Tree
@@ -259,7 +259,7 @@ final case class TermEta(term: Term) extends Term
 final case class TermFunction(params: List[TermParam], body: Term) extends Term
 
 final case class TermId(value: String) extends TermPath with NamedId {
-  def sid = TermSid(value)
+  def name = TermName(value)
 }
 
 final case class TermIf(cond: Term, thenp: Term, elsep: Option[Term])
@@ -321,7 +321,7 @@ final case class TptFunction(targs: List[Tpt]) extends TptApply {
 }
 
 final case class TptId(value: String) extends TptPath with NamedId {
-  def sid = TypeSid(value)
+  def name = TypeName(value)
 }
 
 sealed trait TptPath extends Tpt with Path

--- a/rsc/src/main/scala/rsc/typecheck/Linker.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Linker.scala
@@ -32,7 +32,7 @@ final class Linker private (
   }
 
   private def createPackage(owner: Symbol, value: String): Symbol = {
-    val sid = TermSid(value)
+    val name = TermName(value)
     val sym = {
       if (owner == "π.") value + "."
       else owner + value + "."
@@ -41,7 +41,7 @@ final class Linker private (
     val scope = PackageScope(sym)
     todo.scopes.add(Env() -> scope)
     val ownerScope = symtab.scopes(owner)
-    ownerScope.enter(sid, sym) match {
+    ownerScope.enter(name, sym) match {
       case NoSymbol =>
         symtab.scopes(sym) = scope
         symtab.outlines(sym) = outline

--- a/rsc/src/main/scala/rsc/typecheck/Linker.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Linker.scala
@@ -22,30 +22,30 @@ final class Linker private (
     // See stdlib/src/main/scala/Stdlib.scala for an example for such stubs.
   }
 
-  private def createPi(): Uid = {
-    val uid = "π."
-    val scope = PackageScope(uid)
-    symtab.scopes(uid) = scope
+  private def createPi(): Symbol = {
+    val sym = "π."
+    val scope = PackageScope(sym)
+    symtab.scopes(sym) = scope
     todo.scopes.add(Env(), scope)
-    symtab.outlines(uid) = DefnPackage(TermId("π").withUid(uid), Nil)
-    uid
+    symtab.outlines(sym) = DefnPackage(TermId("π").withSym(sym), Nil)
+    sym
   }
 
-  private def createPackage(owner: Uid, value: String): Uid = {
+  private def createPackage(owner: Symbol, value: String): Symbol = {
     val sid = TermSid(value)
-    val uid = {
+    val sym = {
       if (owner == "π.") value + "."
       else owner + value + "."
     }
-    val outline = DefnPackage(TermId(value).withUid(uid), Nil)
-    val scope = PackageScope(uid)
+    val outline = DefnPackage(TermId(value).withSym(sym), Nil)
+    val scope = PackageScope(sym)
     todo.scopes.add(Env() -> scope)
     val ownerScope = symtab.scopes(owner)
-    ownerScope.enter(sid, uid) match {
-      case NoUid =>
-        symtab.scopes(uid) = scope
-        symtab.outlines(uid) = outline
-        uid
+    ownerScope.enter(sid, sym) match {
+      case NoSymbol =>
+        symtab.scopes(sym) = scope
+        symtab.outlines(sym) = outline
+        sym
       case _ =>
         crash(ownerScope)
     }

--- a/rsc/src/main/scala/rsc/typecheck/Outliner.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Outliner.scala
@@ -34,7 +34,7 @@ final class Outliner private (
           args.foreach(arg => assignSyms(startingEnv, arg.atoms))
           loop(env, rest)
         case IdAtom(id) :: rest =>
-          env.lookup(id.sid) match {
+          env.lookup(id.name) match {
             case NoSymbol =>
               if (env == startingEnv) reporter.append(UnboundId(id))
               else reporter.append(UnboundMember(env.owner.sym, id))
@@ -44,7 +44,7 @@ final class Outliner private (
               else loop(Env(symtab.scopes(sym)), rest)
           }
         case ThisAtom(id) :: rest =>
-          env.lookupThis(id.sidopt) match {
+          env.lookupThis(id.nameopt) match {
             case NoSymbol =>
               reporter.append(UnboundId(id))
             case sym =>
@@ -53,7 +53,7 @@ final class Outliner private (
               else loop(Env(symtab.scopes(sym)), rest)
           }
         case SuperAtom(id) :: rest =>
-          env.lookupSuper(id.sidopt) match {
+          env.lookupSuper(id.nameopt) match {
             case NoSymbol =>
               reporter.append(UnboundId(id))
             case sym =>

--- a/rsc/src/main/scala/rsc/typecheck/Outliner.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Outliner.scala
@@ -13,53 +13,53 @@ final class Outliner private (
     reporter: Reporter,
     symtab: Symtab) {
   def apply(env: Env, tpt: Tpt): Unit = {
-    assignUids(env, tpt.atoms)
+    assignSyms(env, tpt.atoms)
   }
 
   def apply(env: Env, mod: Mod): Unit = {
     mod match {
       case ModPrivate(Some(id: SomeId)) =>
-        assignUids(env, id.atoms)
+        assignSyms(env, id.atoms)
       case ModProtected(Some(id: SomeId)) =>
-        assignUids(env, id.atoms)
+        assignSyms(env, id.atoms)
       case _ =>
         ()
     }
   }
 
-  private def assignUids(startingEnv: Env, atoms: List[Atom]): Unit = {
+  private def assignSyms(startingEnv: Env, atoms: List[Atom]): Unit = {
     def loop(env: Env, atoms: List[Atom]): Unit = {
       atoms match {
         case ApplyAtom(args) :: rest =>
-          args.foreach(arg => assignUids(startingEnv, arg.atoms))
+          args.foreach(arg => assignSyms(startingEnv, arg.atoms))
           loop(env, rest)
         case IdAtom(id) :: rest =>
           env.lookup(id.sid) match {
-            case NoUid =>
+            case NoSymbol =>
               if (env == startingEnv) reporter.append(UnboundId(id))
-              else reporter.append(UnboundMember(env.owner.uid, id))
-            case uid =>
-              id.uid = uid
+              else reporter.append(UnboundMember(env.owner.sym, id))
+            case sym =>
+              id.sym = sym
               if (rest.isEmpty) ()
-              else loop(Env(symtab.scopes(uid)), rest)
+              else loop(Env(symtab.scopes(sym)), rest)
           }
         case ThisAtom(id) :: rest =>
           env.lookupThis(id.sidopt) match {
-            case NoUid =>
+            case NoSymbol =>
               reporter.append(UnboundId(id))
-            case uid =>
-              id.uid = uid
+            case sym =>
+              id.sym = sym
               if (rest.isEmpty) ()
-              else loop(Env(symtab.scopes(uid)), rest)
+              else loop(Env(symtab.scopes(sym)), rest)
           }
         case SuperAtom(id) :: rest =>
           env.lookupSuper(id.sidopt) match {
-            case NoUid =>
+            case NoSymbol =>
               reporter.append(UnboundId(id))
-            case uid =>
-              id.uid = uid
+            case sym =>
+              id.sym = sym
               if (rest.isEmpty) ()
-              else loop(Env(symtab.scopes(uid)), rest)
+              else loop(Env(symtab.scopes(sym)), rest)
           }
         case (atom @ UnsupportedAtom(unsupported)) :: rest =>
           reporter.append(IllegalOutlinePart(unsupported))

--- a/rsc/src/main/scala/rsc/typecheck/Scheduler.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Scheduler.scala
@@ -35,12 +35,12 @@ final class Scheduler private (
       outline: Outline): Symbol = {
     val proposedSym = {
       owner match {
-        case _: FlatScope => owner.sym + id.sid.str
-        case _: PackageScope => owner.sym + id.sid.str
-        case _: TemplateScope => owner.sym + id.sid.str
+        case _: FlatScope => owner.sym + id.name.str
+        case _: PackageScope => owner.sym + id.name.str
+        case _: TemplateScope => owner.sym + id.name.str
       }
     }
-    owner.enter(id.sid, proposedSym) match {
+    owner.enter(id.name, proposedSym) match {
       case NoSymbol =>
         id.sym = proposedSym
         symtab.outlines(id.sym) = outline
@@ -81,8 +81,8 @@ final class Scheduler private (
           case _ => crash(tree)
         }
       }
-      val proposedSym = qualEnv.owner.sym + id.sid.str
-      qualEnv.owner.enter(id.sid, proposedSym) match {
+      val proposedSym = qualEnv.owner.sym + id.name.str
+      qualEnv.owner.enter(id.name, proposedSym) match {
         case NoSymbol =>
           id.sym = proposedSym
           val packageScope = PackageScope(id.sym)
@@ -122,7 +122,7 @@ final class Scheduler private (
           assignSym(templateScope, tree.ctor.id, tree.ctor)
         }
         todo.scopes.add(tparamEnv -> templateScope)
-        tree.ctor.params.foreach(p => templateScope.enter(p.id.sid, p.id.sym))
+        tree.ctor.params.foreach(p => templateScope.enter(p.id.name, p.id.sym))
         templateScope :: ctorEnv
       }
       stats(templateEnv, tree.stats)

--- a/rsc/src/main/scala/rsc/typecheck/Scoper.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Scoper.scala
@@ -129,11 +129,11 @@ final class Scoper private (
           case atom: ApplyAtom =>
             crash(atom)
           case IdAtom(id) =>
-            assignSym(env, id, env.resolve(id.sid))
+            assignSym(env, id, env.resolve(id.name))
           case ThisAtom(id) =>
-            assignSym(env, id, env.resolveThis(id.sidopt))
+            assignSym(env, id, env.resolveThis(id.nameopt))
           case SuperAtom(id) =>
-            assignSym(env, id, env.resolveSuper(id.sidopt))
+            assignSym(env, id, env.resolveSuper(id.nameopt))
           case atom: UnsupportedAtom =>
             ErrorResolution
         }

--- a/rsc/src/main/scala/rsc/typecheck/Scoper.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Scoper.scala
@@ -32,7 +32,7 @@ final class Scoper private (
   }
 
   private def trySucceed(env: Env, scope: ImporterScope): Unit = {
-    val qualResolution = assignUids(env, scope.tree.qual)
+    val qualResolution = assignSyms(env, scope.tree.qual)
     qualResolution match {
       case BlockedResolution(dep) =>
         scope.block(dep)
@@ -58,8 +58,8 @@ final class Scoper private (
       if (scope.tree.inits.nonEmpty) {
         scope.tree.inits
       } else {
-        if (scope.tree.id.uid == "_root_.scala.Any#") Nil
-        else List(Init(TptId("AnyRef").withUid("_root_.scala.AnyRef#"), Nil))
+        if (scope.tree.id.sym == "_root_.scala.Any#") Nil
+        else List(Init(TptId("AnyRef").withSym("_root_.scala.AnyRef#"), Nil))
       }
     }
     inits.foreach {
@@ -68,7 +68,7 @@ final class Scoper private (
           def loop(tpt: Tpt): Resolution = {
             tpt match {
               case tpt: TptPath =>
-                assignUids(env, tpt)
+                assignSyms(env, tpt)
               case TptApply(tpt, _) =>
                 loop(tpt)
             }
@@ -78,8 +78,8 @@ final class Scoper private (
               scope.block(dep)
             case _: FailedResolution =>
               scope.fail()
-            case FoundResolution(uid) =>
-              symtab.scopes(uid) match {
+            case FoundResolution(sym) =>
+              symtab.scopes(sym) match {
                 case parentScope: TemplateScope => buf += parentScope
                 case other => crash(other)
               }
@@ -99,27 +99,27 @@ final class Scoper private (
     }
   }
 
-  private def assignUids(startingEnv: Env, path: Path): Resolution = {
-    def assignUid(env: Env, id: Id, resolver: => Resolution): Resolution = {
-      val cachedUid = id.uid
-      cachedUid match {
-        case NoUid =>
+  private def assignSyms(startingEnv: Env, path: Path): Resolution = {
+    def assignSym(env: Env, id: Id, resolver: => Resolution): Resolution = {
+      val cachedSym = id.sym
+      cachedSym match {
+        case NoSymbol =>
           val resolution = resolver
           resolution match {
             case BlockedResolution(_) =>
               resolution
             case MissingResolution =>
               if (env == startingEnv) reporter.append(UnboundId(id))
-              else reporter.append(UnboundMember(env.owner.uid, id))
+              else reporter.append(UnboundMember(env.owner.sym, id))
               ErrorResolution
             case ErrorResolution =>
               ErrorResolution
-            case FoundResolution(uid) =>
-              id.uid = uid
+            case FoundResolution(sym) =>
+              id.sym = sym
               resolution
           }
-        case cachedUid =>
-          FoundResolution(cachedUid)
+        case cachedSym =>
+          FoundResolution(cachedSym)
       }
     }
     def loop(env: Env, atoms: List[Atom]): Resolution = {
@@ -129,11 +129,11 @@ final class Scoper private (
           case atom: ApplyAtom =>
             crash(atom)
           case IdAtom(id) =>
-            assignUid(env, id, env.resolve(id.sid))
+            assignSym(env, id, env.resolve(id.sid))
           case ThisAtom(id) =>
-            assignUid(env, id, env.resolveThis(id.sidopt))
+            assignSym(env, id, env.resolveThis(id.sidopt))
           case SuperAtom(id) =>
-            assignUid(env, id, env.resolveSuper(id.sidopt))
+            assignSym(env, id, env.resolveSuper(id.sidopt))
           case atom: UnsupportedAtom =>
             ErrorResolution
         }
@@ -143,9 +143,9 @@ final class Scoper private (
           resolution
         case _: FailedResolution =>
           resolution
-        case FoundResolution(uid) =>
+        case FoundResolution(sym) =>
           if (rest.isEmpty) resolution
-          else loop(Env(symtab.scopes(uid)), rest)
+          else loop(Env(symtab.scopes(sym)), rest)
       }
     }
     loop(startingEnv, path.atoms)

--- a/rsc/src/main/scala/rsc/typecheck/Typechecker.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Typechecker.scala
@@ -127,8 +127,8 @@ final class Typechecker private (
         val scope = FlatScope("block")
         stats.foreach {
           case stat @ DefnField(_, id, tpt, Some(rhs)) =>
-            val sym = scope.sym + id.sid.str
-            scope.enter(id.sid, sym) match {
+            val sym = scope.sym + id.name.str
+            scope.enter(id.name, sym) match {
               case NoSymbol =>
                 id.sym = sym
                 symtab.outlines(id.sym) = stat
@@ -160,8 +160,8 @@ final class Typechecker private (
     val scope = FlatScope("lambda")
     tree.params.foreach {
       case param @ TermParam(_, id, tpt) =>
-        val sym = scope.sym + id.sid.str
-        scope.enter(id.sid, sym) match {
+        val sym = scope.sym + id.name.str
+        scope.enter(id.name, sym) match {
           case NoSymbol =>
             id.sym = sym
             symtab.outlines(id.sym) = param
@@ -178,7 +178,7 @@ final class Typechecker private (
   }
 
   private def termId(env: Env, tree: TermId): Type = {
-    env.lookup(tree.sid) match {
+    env.lookup(tree.name) match {
       case NoSymbol =>
         reporter.append(UnboundId(tree))
         NoType
@@ -240,8 +240,8 @@ final class Typechecker private (
             case pat @ PatVar(id: NamedId, tpt) =>
               tpt match {
                 case Some(tpt) =>
-                  val sym = scope.sym + id.sid.str
-                  scope.enter(id.sid, sym) match {
+                  val sym = scope.sym + id.name.str
+                  scope.enter(id.name, sym) match {
                     case NoSymbol =>
                       id.sym = sym
                       symtab.outlines(id.sym) = pat
@@ -294,7 +294,7 @@ final class Typechecker private (
       case qualTpe: SimpleType =>
         def lookup(qualSym: Symbol): Type = {
           val qualScope = symtab.scopes(qualSym)
-          qualScope.lookup(tree.id.sid) match {
+          qualScope.lookup(tree.id.name) match {
             case NoSymbol =>
               if (tree.id.value.isOpAssignment) {
                 val value1 = tree.id.value.stripSuffix("=")
@@ -334,14 +334,14 @@ final class Typechecker private (
   }
 
   private def termSuper(env: Env, tree: TermSuper): Type = {
-    env.lookupThis(tree.qual.sidopt) match {
+    env.lookupThis(tree.qual.nameopt) match {
       case NoSymbol =>
         reporter.append(UnboundId(tree.qual))
         NoType
       case qualSym =>
         tree.qual.sym = qualSym
         val env1 = Env(symtab.scopes(qualSym))
-        env1.lookupSuper(tree.mix.sidopt) match {
+        env1.lookupSuper(tree.mix.nameopt) match {
           case NoSymbol =>
             reporter.append(UnboundId(tree.mix))
             NoType
@@ -359,7 +359,7 @@ final class Typechecker private (
   }
 
   private def termThis(env: Env, tree: TermThis): Type = {
-    env.lookupThis(tree.qual.sidopt) match {
+    env.lookupThis(tree.qual.nameopt) match {
       case NoSymbol =>
         reporter.append(UnboundId(tree.id))
         NoType
@@ -404,7 +404,7 @@ final class Typechecker private (
   }
 
   private def tptId(env: Env, tree: TptId): Type = {
-    env.lookup(tree.sid) match {
+    env.lookup(tree.name) match {
       case NoSymbol =>
         reporter.append(UnboundId(tree))
         NoType
@@ -421,7 +421,7 @@ final class Typechecker private (
         NoType
       case SimpleType(qualSym, Nil) =>
         val qualScope = symtab.scopes(qualSym)
-        qualScope.lookup(tree.id.sid) match {
+        qualScope.lookup(tree.id.name) match {
           case NoSymbol =>
             reporter.append(UnboundMember(qualSym, tree.id))
             NoType

--- a/rsc/src/main/scala/rsc/typecheck/Typechecker.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Typechecker.scala
@@ -127,13 +127,13 @@ final class Typechecker private (
         val scope = FlatScope("block")
         stats.foreach {
           case stat @ DefnField(_, id, tpt, Some(rhs)) =>
-            val uid = scope.uid + id.sid.str
-            scope.enter(id.sid, uid) match {
-              case NoUid =>
-                id.uid = uid
-                symtab.outlines(id.uid) = stat
-              case existingUid =>
-                reporter.append(DoubleDef(stat, symtab.outlines(existingUid)))
+            val sym = scope.sym + id.sid.str
+            scope.enter(id.sid, sym) match {
+              case NoSymbol =>
+                id.sym = sym
+                symtab.outlines(id.sym) = stat
+              case existingSym =>
+                reporter.append(DoubleDef(stat, symtab.outlines(existingSym)))
                 return NoType
             }
             tpts += tpt
@@ -160,13 +160,13 @@ final class Typechecker private (
     val scope = FlatScope("lambda")
     tree.params.foreach {
       case param @ TermParam(_, id, tpt) =>
-        val uid = scope.uid + id.sid.str
-        scope.enter(id.sid, uid) match {
-          case NoUid =>
-            id.uid = uid
-            symtab.outlines(id.uid) = param
-          case existingUid =>
-            reporter.append(DoubleDef(param, symtab.outlines(existingUid)))
+        val sym = scope.sym + id.sid.str
+        scope.enter(id.sid, sym) match {
+          case NoSymbol =>
+            id.sym = sym
+            symtab.outlines(id.sym) = param
+          case existingSym =>
+            reporter.append(DoubleDef(param, symtab.outlines(existingSym)))
             return NoType
         }
         tpts += tpt
@@ -179,12 +179,12 @@ final class Typechecker private (
 
   private def termId(env: Env, tree: TermId): Type = {
     env.lookup(tree.sid) match {
-      case NoUid =>
+      case NoSymbol =>
         reporter.append(UnboundId(tree))
         NoType
-      case uid =>
-        tree.uid = uid
-        uid.tpe
+      case sym =>
+        tree.sym = sym
+        sym.tpe
     }
   }
 
@@ -231,7 +231,7 @@ final class Typechecker private (
             case pat: PatId =>
               val tree1 = TermId(pat.value).withPos(pat)
               apply(env, tree1)
-              pat.uid = tree1.uid
+              pat.sym = tree1.sym
             case pat: PatLit =>
               ()
             case pat: PatSelect =>
@@ -240,14 +240,14 @@ final class Typechecker private (
             case pat @ PatVar(id: NamedId, tpt) =>
               tpt match {
                 case Some(tpt) =>
-                  val uid = scope.uid + id.sid.str
-                  scope.enter(id.sid, uid) match {
-                    case NoUid =>
-                      id.uid = uid
-                      symtab.outlines(id.uid) = pat
+                  val sym = scope.sym + id.sid.str
+                  scope.enter(id.sid, sym) match {
+                    case NoSymbol =>
+                      id.sym = sym
+                      symtab.outlines(id.sym) = pat
                       pat.tpe = apply(env, tpt)
-                    case existingUid =>
-                      val message = DoubleDef(pat, symtab.outlines(existingUid))
+                    case existingSym =>
+                      val message = DoubleDef(pat, symtab.outlines(existingSym))
                       reporter.append(message)
                   }
                 case None =>
@@ -292,22 +292,22 @@ final class Typechecker private (
         reporter.append(NonValue(tree.qual, qualTpe))
         NoType
       case qualTpe: SimpleType =>
-        def lookup(qualUid: Uid): Type = {
-          val qualScope = symtab.scopes(qualUid)
+        def lookup(qualSym: Symbol): Type = {
+          val qualScope = symtab.scopes(qualSym)
           qualScope.lookup(tree.id.sid) match {
-            case NoUid =>
+            case NoSymbol =>
               if (tree.id.value.isOpAssignment) {
                 val value1 = tree.id.value.stripSuffix("=")
                 val id1 = TermId(value1).withPos(tree.id)
                 val tree1 = TermSelect(tree.qual, id1).withPos(tree)
                 apply(env, tree1)
               } else {
-                reporter.append(UnboundMember(qualUid, tree.id))
+                reporter.append(UnboundMember(qualSym, tree.id))
                 NoType
               }
-            case uid =>
-              tree.id.uid = uid
-              uid.tpe
+            case sym =>
+              tree.id.sym = sym
+              sym.tpe
           }
         }
         def loop(qualTpe: Type): Type = {
@@ -316,12 +316,12 @@ final class Typechecker private (
               NoType
             case _: MethodType =>
               crash(qualTpe)
-            case SimpleType(qualUid, targs) =>
-              symtab.outlines(qualUid) match {
+            case SimpleType(qualSym, targs) =>
+              symtab.outlines(qualSym) match {
                 case DefnPackage(pid, _) =>
-                  lookup(pid.id.uid)
+                  lookup(pid.id.sym)
                 case DefnTemplate(_, id, tparams, _, _, _) =>
-                  lookup(id.uid).subst(tparams, targs)
+                  lookup(id.sym).subst(tparams, targs)
                 case DefnType(_, _, tparams, tpt) =>
                   loop(tpt.tpe.subst(tparams, targs))
                 case tparam: TypeParam =>
@@ -335,22 +335,22 @@ final class Typechecker private (
 
   private def termSuper(env: Env, tree: TermSuper): Type = {
     env.lookupThis(tree.qual.sidopt) match {
-      case NoUid =>
+      case NoSymbol =>
         reporter.append(UnboundId(tree.qual))
         NoType
-      case qualUid =>
-        tree.qual.uid = qualUid
-        val env1 = Env(symtab.scopes(qualUid))
+      case qualSym =>
+        tree.qual.sym = qualSym
+        val env1 = Env(symtab.scopes(qualSym))
         env1.lookupSuper(tree.mix.sidopt) match {
-          case NoUid =>
+          case NoSymbol =>
             reporter.append(UnboundId(tree.mix))
             NoType
-          case mixUid =>
-            tree.mix.uid = mixUid
-            symtab.outlines(mixUid) match {
+          case mixSym =>
+            tree.mix.sym = mixSym
+            symtab.outlines(mixSym) match {
               case DefnTemplate(_, id, tparams, _, _, _) =>
-                val targs = tparams.map(tp => SimpleType(tp.id.uid, Nil))
-                SimpleType(id.uid, targs)
+                val targs = tparams.map(tp => SimpleType(tp.id.sym, Nil))
+                SimpleType(id.sym, targs)
               case other =>
                 crash(other)
             }
@@ -360,15 +360,15 @@ final class Typechecker private (
 
   private def termThis(env: Env, tree: TermThis): Type = {
     env.lookupThis(tree.qual.sidopt) match {
-      case NoUid =>
+      case NoSymbol =>
         reporter.append(UnboundId(tree.id))
         NoType
-      case qualUid =>
-        tree.qual.uid = qualUid
-        symtab.outlines(qualUid) match {
+      case qualSym =>
+        tree.qual.sym = qualSym
+        symtab.outlines(qualSym) match {
           case DefnTemplate(_, id, tparams, _, _, _) =>
-            val targs = tparams.map(tparam => SimpleType(tparam.id.uid, Nil))
-            SimpleType(id.uid, targs)
+            val targs = tparams.map(tparam => SimpleType(tparam.id.sym, Nil))
+            SimpleType(id.sym, targs)
           case other =>
             crash(other)
         }
@@ -390,14 +390,14 @@ final class Typechecker private (
     funTpe match {
       case NoType =>
         NoType
-      case SimpleType(funUid, Nil) =>
+      case SimpleType(funSym, Nil) =>
         val targs = tree.targs.map {
           apply(env, _) match {
             case targ: SimpleType => targ
             case other => crash(other)
           }
         }
-        SimpleType(funUid, targs)
+        SimpleType(funSym, targs)
       case other =>
         crash(other)
     }
@@ -405,12 +405,12 @@ final class Typechecker private (
 
   private def tptId(env: Env, tree: TptId): Type = {
     env.lookup(tree.sid) match {
-      case NoUid =>
+      case NoSymbol =>
         reporter.append(UnboundId(tree))
         NoType
-      case uid =>
-        tree.uid = uid
-        SimpleType(uid, Nil)
+      case sym =>
+        tree.sym = sym
+        SimpleType(sym, Nil)
     }
   }
 
@@ -419,15 +419,15 @@ final class Typechecker private (
     qualTpe match {
       case NoType =>
         NoType
-      case SimpleType(qualUid, Nil) =>
-        val qualScope = symtab.scopes(qualUid)
+      case SimpleType(qualSym, Nil) =>
+        val qualScope = symtab.scopes(qualSym)
         qualScope.lookup(tree.id.sid) match {
-          case NoUid =>
-            reporter.append(UnboundMember(qualUid, tree.id))
+          case NoSymbol =>
+            reporter.append(UnboundMember(qualSym, tree.id))
             NoType
-          case uid =>
-            tree.id.uid = uid
-            SimpleType(tree.id.uid, Nil)
+          case sym =>
+            tree.id.sym = sym
+            SimpleType(tree.id.sym, Nil)
         }
       case other =>
         crash(other)
@@ -466,33 +466,33 @@ final class Typechecker private (
     def tpe: SimpleType = {
       tpt match {
         case TptApply(fun: TptPath, targs) =>
-          if (fun.id.uid == NoUid) crash(fun)
-          else SimpleType(fun.id.uid, targs.map(_.tpe))
+          if (fun.id.sym == NoSymbol) crash(fun)
+          else SimpleType(fun.id.sym, targs.map(_.tpe))
         case _: TptApply =>
           crash(tpt)
         case tpt: TptPath =>
-          if (tpt.id.uid == NoUid) crash(tpt.id)
-          else SimpleType(tpt.id.uid, Nil)
+          if (tpt.id.sym == NoSymbol) crash(tpt.id)
+          else SimpleType(tpt.id.sym, Nil)
       }
     }
   }
 
-  private implicit class TypecheckerUidOps(uid: Uid) {
+  private implicit class TypecheckerSymbolOps(sym: Symbol) {
     def tpe: Type = {
-      symtab.outlines(uid) match {
+      symtab.outlines(sym) match {
         case DefnDef(_, _, tparams, params, ret, _) =>
-          val tpeTparams = tparams.map(_.id.uid)
-          val tpeParams = params.map(_.id.uid)
+          val tpeTparams = tparams.map(_.id.sym)
+          val tpeParams = params.map(_.id.sym)
           val tpeRet = ret.tpe
           MethodType(tpeTparams, tpeParams, tpeRet)
         case DefnField(_, _, tpt, _) =>
           tpt.tpe
         case DefnObject(_, id, _, _) =>
-          SimpleType(id.uid, Nil)
+          SimpleType(id.sym, Nil)
         case DefnPackage(id: TermId, _) =>
-          SimpleType(id.uid, Nil)
+          SimpleType(id.sym, Nil)
         case DefnPackage(TermSelect(_, id: TermId), _) =>
-          SimpleType(id.uid, Nil)
+          SimpleType(id.sym, Nil)
         case pat: PatVar =>
           pat.tpe
         case TermParam(_, _, tpt) =>
@@ -512,7 +512,7 @@ final class Typechecker private (
           case NoType =>
             NoType
           case tpe: MethodType =>
-            val tparams1 = tpe.tparams.diff(tparams.map(_.id.uid))
+            val tparams1 = tpe.tparams.diff(tparams.map(_.id.sym))
             val params1 = tpe.params
             val ret1 = {
               tpe.ret.subst(tparams, targs) match {
@@ -522,23 +522,23 @@ final class Typechecker private (
             }
             MethodType(tparams1, params1, ret1)
           case tpe: SimpleType =>
-            val i = tparams.indexWhere(_.id.uid == tpe.uid)
+            val i = tparams.indexWhere(_.id.sym == tpe.sym)
             if (i != -1) {
               targs(i)
             } else {
-              val uid1 = tpe.uid
+              val sym1 = tpe.sym
               val targs1 = tpe.targs.map {
                 _.subst(tparams, targs) match {
                   case targ1: SimpleType => targ1
                   case other => crash(other)
                 }
               }
-              SimpleType(uid1, targs1)
+              SimpleType(sym1, targs1)
             }
         }
       }
     }
-    def subst(tparams: Seq[Uid], targs: List[SimpleType]): Type = {
+    def subst(tparams: Seq[Symbol], targs: List[SimpleType]): Type = {
       if (tparams.isEmpty && targs.isEmpty) {
         tpe
       } else {
@@ -556,18 +556,18 @@ final class Typechecker private (
             }
             MethodType(tparams1, params1, ret1)
           case tpe: SimpleType =>
-            val i = tparams.indexWhere(_ == tpe.uid)
+            val i = tparams.indexWhere(_ == tpe.sym)
             if (i != -1) {
               targs(i)
             } else {
-              val uid1 = tpe.uid
+              val sym1 = tpe.sym
               val targs1 = tpe.targs.map {
                 _.subst(tparams, targs) match {
                   case targ1: SimpleType => targ1
                   case other => crash(other)
                 }
               }
-              SimpleType(uid1, targs1)
+              SimpleType(sym1, targs1)
             }
         }
       }

--- a/rsc/src/main/scala/rsc/util/TreeUtil.scala
+++ b/rsc/src/main/scala/rsc/util/TreeUtil.scala
@@ -7,9 +7,9 @@ import rsc.syntax._
 
 trait TreeUtil {
   implicit class UtilIdOps(id: Id) {
-    def sidopt: Option[Sid] = {
+    def nameopt: Option[Name] = {
       id match {
-        case id: NamedId => Some(id.sid)
+        case id: NamedId => Some(id.name)
         case _ => None
       }
     }


### PR DESCRIPTION
`Uid` and `Sid` have proven to be confusing to newcomers, even though they have direct analogs in other Scala compilers. In order to simplify knowledge transfer, I'll be renaming them to `Symbol` and `Name`.