### PR TITLE
Move typecheck-specific code to rsc.typecheck

### DIFF
--- a/bench/rsc/jvm/src/main/scala/rsc/bench/RscOutline.scala
+++ b/bench/rsc/jvm/src/main/scala/rsc/bench/RscOutline.scala
@@ -6,7 +6,6 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.annotations.Mode._
 import rsc.bench.RscOutline._
-import rsc.semantics._
 
 object RscOutline {
   @State(Scope.Benchmark)

--- a/bench/rsc/jvm/src/main/scala/rsc/bench/RscSchedule.scala
+++ b/bench/rsc/jvm/src/main/scala/rsc/bench/RscSchedule.scala
@@ -6,7 +6,6 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.annotations.Mode._
 import rsc.bench.RscSchedule._
-import rsc.semantics._
 
 object RscSchedule {
   @State(Scope.Benchmark)

--- a/bench/rsc/jvm/src/main/scala/rsc/bench/RscScope.scala
+++ b/bench/rsc/jvm/src/main/scala/rsc/bench/RscScope.scala
@@ -6,7 +6,6 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.annotations.Mode._
 import rsc.bench.RscScope._
-import rsc.semantics._
 
 object RscScope {
   @State(Scope.Benchmark)

--- a/bench/rsc/jvm/src/main/scala/rsc/bench/RscTypecheck.scala
+++ b/bench/rsc/jvm/src/main/scala/rsc/bench/RscTypecheck.scala
@@ -6,7 +6,6 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.annotations.Mode._
 import rsc.bench.RscTypecheck._
-import rsc.semantics._
 
 object RscTypecheck {
   @State(Scope.Benchmark)

--- a/rsc/src/main/scala/rsc/Compiler.scala
+++ b/rsc/src/main/scala/rsc/Compiler.scala
@@ -7,7 +7,6 @@ import rsc.lexis._
 import rsc.parse._
 import rsc.pretty._
 import rsc.report._
-import rsc.semantics._
 import rsc.settings._
 import rsc.syntax._
 import rsc.typecheck._

--- a/rsc/src/main/scala/rsc/pretty/PrettyEnv.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyEnv.scala
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.pretty
 
-import rsc.semantics._
+import rsc.typecheck._
 import rsc.util._
 
 object PrettyEnv {

--- a/rsc/src/main/scala/rsc/pretty/PrettyResolution.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyResolution.scala
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.pretty
 
-import rsc.semantics._
+import rsc.typecheck._
 
 object PrettyResolution {
   def str(p: Printer, x: Resolution): Unit = {

--- a/rsc/src/main/scala/rsc/pretty/PrettyScope.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyScope.scala
@@ -3,7 +3,7 @@
 package rsc.pretty
 
 import scala.collection.JavaConverters._
-import rsc.semantics._
+import rsc.typecheck._
 import rsc.util._
 
 object PrettyScope {

--- a/rsc/src/main/scala/rsc/pretty/PrettyStatus.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyStatus.scala
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.pretty
 
-import rsc.semantics._
+import rsc.typecheck._
 
 object PrettyStatus {
   def str(p: Printer, x: Status): Unit = {

--- a/rsc/src/main/scala/rsc/pretty/PrettySymtab.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySymtab.scala
@@ -3,7 +3,7 @@
 package rsc.pretty
 
 import scala.collection.JavaConverters._
-import rsc.semantics._
+import rsc.typecheck._
 import rsc.util._
 
 object PrettySymtab {

--- a/rsc/src/main/scala/rsc/report/Messages.scala
+++ b/rsc/src/main/scala/rsc/report/Messages.scala
@@ -7,6 +7,7 @@ import rsc.lexis._
 import rsc.pretty._
 import rsc.semantics._
 import rsc.syntax._
+import rsc.typecheck._
 import rsc.util._
 
 sealed trait Message extends Pretty with Product {

--- a/rsc/src/main/scala/rsc/typecheck/Envs.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Envs.scala
@@ -1,9 +1,10 @@
 // Copyright (c) 2017-2018 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
-package rsc.semantics
+package rsc.typecheck
 
 import scala.annotation.tailrec
 import rsc.pretty._
+import rsc.semantics._
 import rsc.util._
 
 sealed class Env protected (val _scopes: List[Scope]) extends Pretty {

--- a/rsc/src/main/scala/rsc/typecheck/Resolutions.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Resolutions.scala
@@ -1,8 +1,9 @@
 // Copyright (c) 2017-2018 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
-package rsc.semantics
+package rsc.typecheck
 
 import rsc.pretty._
+import rsc.semantics._
 
 sealed trait Resolution extends Pretty with Product {
   override def printStr(p: Printer): Unit = PrettyResolution.str(p, this)

--- a/rsc/src/main/scala/rsc/typecheck/Scopes.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Scopes.scala
@@ -1,10 +1,11 @@
 // Copyright (c) 2017-2018 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
-package rsc.semantics
+package rsc.typecheck
 
 import java.util.{HashMap, Map}
 import scala.collection.mutable
 import rsc.pretty._
+import rsc.semantics._
 import rsc.syntax._
 import rsc.util._
 

--- a/rsc/src/main/scala/rsc/typecheck/Statuses.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Statuses.scala
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-2018 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
-package rsc.semantics
+package rsc.typecheck
 
 import rsc.pretty._
 

--- a/rsc/src/main/scala/rsc/typecheck/Symtab.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Symtab.scala
@@ -1,9 +1,10 @@
 // Copyright (c) 2017-2018 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
-package rsc.semantics
+package rsc.typecheck
 
 import java.util.{HashMap, Map}
 import rsc.pretty._
+import rsc.semantics._
 import rsc.syntax._
 import rsc.util._
 

--- a/rsc/src/main/scala/rsc/typecheck/Todo.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Todo.scala
@@ -4,7 +4,6 @@ package rsc.typecheck
 
 import java.util.{Queue, LinkedList}
 import rsc.pretty._
-import rsc.semantics._
 import rsc.syntax._
 
 final class Todo private extends Pretty {


### PR DESCRIPTION
Very soon, Rsc will gain the capability to load SemanticDBs produced
by metacp and use that information to understand third-party dependencies.

In preparation for that, I asked myself a question: "Which parts of
rsc.semantics make sense both for metadata loaded from SemanticDBs
and metadata computed during typechecking?".

Answering that question led me to believe that lots of data structures
and logic in rsc.semantics belongs to rsc.typecheck instead.
For example, the ceremony around scope statuses, the Scope.lookup/resolve
separation - all that is irrelevant to SemanticDB loading (at least,
as far as I can see now).