### PR TITLE
Introduce SemanticDB-based rsc.symtab.Symtab

### DIFF
--- a/bench/scalac212/src/main/scala/rsc/bench/FileFixtures.scala
+++ b/bench/scalac212/src/main/scala/rsc/bench/FileFixtures.scala
@@ -29,10 +29,10 @@ trait FileFixtures {
   }
 
   lazy val re2sRscFiles: List[Path] = {
-    re2sScalacFiles :+ stdlibPath
+    re2sScalacFiles :+ stdlibSourcepath
   }
 
-  lazy val stdlibPath: Path = {
+  lazy val stdlibSourcepath: Path = {
     buildRoot.resolve("stdlib/src/main/scala/Stdlib.scala")
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ val V = new {
   val scala211 = "2.11.12"
   val scala212 = "2.12.4"
   val uTest = "0.6.0"
+  val scalameta = "3.6.0"
 }
 
 addCommandAlias("benchAll", benchAll.command)
@@ -94,6 +95,7 @@ lazy val rsc = crossProject(JVMPlatform, NativePlatform)
   .nativeSettings(nativeSettings)
   .settings(
     commonSettings,
+    libraryDependencies += "org.scalameta" %%% "semanticdb3" % V.scalameta,
     buildInfoPackage := "rsc.internal",
     buildInfoUsePackageAsPath := true,
     buildInfoKeys := Seq[BuildInfoKey](
@@ -120,7 +122,9 @@ lazy val tests = crossProject(JVMPlatform, NativePlatform)
     buildInfoPackage := "rsc.tests",
     buildInfoUsePackageAsPath := true,
     buildInfoKeys := Seq[BuildInfoKey](
-      "sourceRoot" -> (baseDirectory in ThisBuild).value
+      "sourceRoot" -> (baseDirectory in ThisBuild).value,
+      "scalaLibraryArtifact" -> s"org.scala-lang:scala-library:${scalaVersion.value}",
+      "metacpArtifact" -> s"org.scalameta:metacp_${scalaBinaryVersion.value}:${V.scalameta}"
     )
   )
 lazy val testsJVM = tests.jvm

--- a/build.sbt
+++ b/build.sbt
@@ -123,8 +123,7 @@ lazy val tests = crossProject(JVMPlatform, NativePlatform)
     buildInfoUsePackageAsPath := true,
     buildInfoKeys := Seq[BuildInfoKey](
       "sourceRoot" -> (baseDirectory in ThisBuild).value,
-      "scalaLibraryArtifact" -> s"org.scala-lang:scala-library:${scalaVersion.value}",
-      "metacpArtifact" -> s"org.scalameta:metacp_${scalaBinaryVersion.value}:${V.scalameta}"
+      BuildInfoKey.map(stdlibClasspath) { case (k, v) => k -> v }
     )
   )
 lazy val testsJVM = tests.jvm

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val commonSettings = Seq(
 )
 
 lazy val nativeSettings = Seq(
-  nativeGC := "immix",
+  nativeGC := "boehm",
   nativeMode := "release",
   nativeLinkStubs := true
 )

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ val V = new {
   val scala211 = "2.11.12"
   val scala212 = "2.12.4"
   val uTest = "0.6.0"
-  val scalameta = "3.6.0"
+  val scalameta = computeScalametaVersionFromPluginsSbt()
 }
 
 addCommandAlias("benchAll", benchAll.command)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -135,6 +135,13 @@ object Build extends AutoPlugin {
     val scalafmtTest = taskKey[Unit]("Test formatting with Scalafmt")
     val shell = inputKey[Unit]("Run shell command")
     val stdlibClasspath = taskKey[String]("Compute stdlib classpath")
+
+    def computeScalametaVersionFromPluginsSbt(): String = {
+      val pluginsSbt = IO.read(file("project/plugins.sbt"))
+      val scalametaRegex = """"org.scalameta" %% ".*?" % "(.*)"""".r
+      val scalametaMatch = scalametaRegex.findFirstMatchIn(pluginsSbt)
+      scalametaMatch.map(_.group(1)).get
+    }
   }
 
   override def projectSettings: Seq[Def.Setting[_]] = List(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,5 +5,6 @@ addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "0.3.1")
 // This build is published from my private fork of Scala Native
 // https://github.com/xeno-by/scala-native/commits/topic/scalameta
-addSbtPlugin("com.github.xenoby" %% "sbt-scala-native" % "0.3.6-20-g0afae98f36" exclude("com.lihaoyi", "fastparse_2.12"))
+addSbtPlugin(
+  "com.github.xenoby" %% "sbt-scala-native" % "0.3.6-20-g0afae98f36" exclude ("com.lihaoyi", "fastparse_2.12"))
 libraryDependencies += "org.scalameta" %% "metacp" % "3.6.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,9 @@
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC10")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.25")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "0.3.1")
 // This build is published from my private fork of Scala Native
 // https://github.com/xeno-by/scala-native/commits/topic/scalameta
 addSbtPlugin("com.github.xenoby" %% "sbt-scala-native" % "0.3.6-20-g0afae98f36")
+libraryDependencies += "org.scalameta" %% "metacp" % "3.6.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,5 +5,5 @@ addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "0.3.1")
 // This build is published from my private fork of Scala Native
 // https://github.com/xeno-by/scala-native/commits/topic/scalameta
-addSbtPlugin("com.github.xenoby" %% "sbt-scala-native" % "0.3.6-20-g0afae98f36")
+addSbtPlugin("com.github.xenoby" %% "sbt-scala-native" % "0.3.6-20-g0afae98f36" exclude("com.lihaoyi", "fastparse_2.12"))
 libraryDependencies += "org.scalameta" %% "metacp" % "3.6.0"

--- a/rsc/src/main/scala/rsc/pretty/Instances.scala
+++ b/rsc/src/main/scala/rsc/pretty/Instances.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.pretty
+
+import scala.meta.internal.semanticdb3._
+
+trait Instances {
+  implicit val accStr = Str[Accessibility](PrettySymtabAccessibility.str)
+  implicit val accRepl = Repl[Accessibility](PrettySymtabAccessibility.repl)
+
+  implicit val annStr = Str[Annotation](PrettySymtabAnnotation.str)
+  implicit val annRepl = Repl[Annotation](PrettySymtabAnnotation.repl)
+
+  implicit val infoStr = Str[SymbolInformation](PrettySymtabInfo.str)
+  implicit val infoRepl = Repl[SymbolInformation](PrettySymtabInfo.repl)
+
+  implicit val typeStr = Str[Type](PrettySymtabType.str)
+  implicit val typeRepl = Repl[Type](PrettySymtabType.repl)
+}

--- a/rsc/src/main/scala/rsc/pretty/PrettySemanticType.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySemanticType.scala
@@ -4,7 +4,7 @@ package rsc.pretty
 
 import rsc.semantics._
 
-object PrettyType {
+object PrettySemanticType {
   def str(p: Printer, tpe: Type): Unit = {
     tpe match {
       case NoType =>

--- a/rsc/src/main/scala/rsc/pretty/PrettySymtabAccessibility.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySymtabAccessibility.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.pretty
+
+import scala.meta.internal.semanticdb3._
+import scala.meta.internal.semanticdb3.Accessibility.{Tag => a}
+
+object PrettySymtabAccessibility {
+  def str(p: Printer, x: Accessibility): Unit = {
+    x.tag match {
+      case a.PUBLIC =>
+        p.str("public")
+      case a.PRIVATE =>
+        p.str("private")
+      case a.PRIVATE_THIS =>
+        p.str("private[this]")
+      case a.PRIVATE_WITHIN =>
+        p.str("private[<")
+        if (x.symbol.nonEmpty) p.str(x.symbol)
+        else p.str("?")
+        p.str(">]")
+      case a.PROTECTED =>
+        p.str("protected")
+      case a.PROTECTED_THIS =>
+        p.str("protected[this]")
+      case a.PROTECTED_WITHIN =>
+        p.str("protected[<")
+        if (x.symbol.nonEmpty) p.str(x.symbol)
+        else p.str("?")
+        p.str(">]")
+      case a.UNKNOWN_ACCESSIBILITY | Accessibility.Tag.Unrecognized(_) =>
+        p.str("<?>")
+    }
+  }
+
+  def repl(p: Printer, x: Accessibility): Unit = {
+    // TODO: Implement me.
+    p.str(x.toProtoString)
+  }
+}

--- a/rsc/src/main/scala/rsc/pretty/PrettySymtabAccessibility.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySymtabAccessibility.scala
@@ -34,7 +34,6 @@ object PrettySymtabAccessibility {
   }
 
   def repl(p: Printer, x: Accessibility): Unit = {
-    // TODO: Implement me.
     p.str(x.toProtoString)
   }
 }

--- a/rsc/src/main/scala/rsc/pretty/PrettySymtabAnnotation.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySymtabAnnotation.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.pretty
+
+import scala.meta.internal.semanticdb3._
+
+object PrettySymtabAnnotation {
+  def str(p: Printer, x: Annotation): Unit = {
+    p.str("@")
+    x.tpe match {
+      case Some(tpe) =>
+        p.str(tpe)
+      case None =>
+        p.str("<?>")
+    }
+  }
+
+  def repl(p: Printer, x: Annotation): Unit = {
+    // TODO: Implement me.
+    p.str(x.toProtoString)
+  }
+}

--- a/rsc/src/main/scala/rsc/pretty/PrettySymtabAnnotation.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySymtabAnnotation.scala
@@ -16,7 +16,6 @@ object PrettySymtabAnnotation {
   }
 
   def repl(p: Printer, x: Annotation): Unit = {
-    // TODO: Implement me.
     p.str(x.toProtoString)
   }
 }

--- a/rsc/src/main/scala/rsc/pretty/PrettySymtabInfo.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySymtabInfo.scala
@@ -1,0 +1,84 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.pretty
+
+import scala.meta.internal.semanticdb3._
+import scala.meta.internal.semanticdb3.SymbolInformation._
+import scala.meta.internal.semanticdb3.SymbolInformation.{Kind => k}
+
+object PrettySymtabInfo {
+  def str(p: Printer, x: SymbolInformation): Unit = {
+    if (x.symbol.nonEmpty) {
+      p.str(x.symbol)
+    } else {
+      p.str("<?>")
+    }
+    p.str(" => ")
+    p.rep(x.annotations, " ", " ")(ann => p.str(ann))
+    p.opt(x.accessibility, " ")(acc => p.str(acc))
+    def has(prop: Property) = (x.properties & prop.value) != 0
+    if (has(Property.ABSTRACT)) p.str("abstract ")
+    if (has(Property.FINAL)) p.str("final ")
+    if (has(Property.SEALED)) p.str("sealed ")
+    if (has(Property.IMPLICIT)) p.str("implicit ")
+    if (has(Property.LAZY)) p.str("lazy ")
+    if (has(Property.CASE)) p.str("case ")
+    if (has(Property.COVARIANT)) p.str("covariant ")
+    if (has(Property.CONTRAVARIANT)) p.str("contravariant ")
+    if (has(Property.VAL)) p.str("val ")
+    if (has(Property.VAR)) p.str("var ")
+    if (has(Property.STATIC)) p.str("static ")
+    if (has(Property.PRIMARY)) p.str("primary ")
+    x.kind match {
+      case k.LOCAL => p.str("local ")
+      case k.FIELD => p.str("field ")
+      case k.METHOD => p.str("method ")
+      case k.CONSTRUCTOR => p.str("constructor ")
+      case k.MACRO => p.str("macro ")
+      case k.TYPE => p.str("type ")
+      case k.PARAMETER => p.str("param ")
+      case k.SELF_PARAMETER => p.str("selfparam ")
+      case k.TYPE_PARAMETER => p.str("typeparam ")
+      case k.OBJECT => p.str("object ")
+      case k.PACKAGE => p.str("package ")
+      case k.PACKAGE_OBJECT => p.str("package object ")
+      case k.CLASS => p.str("class ")
+      case k.TRAIT => p.str("trait ")
+      case k.INTERFACE => p.str("interface ")
+      case k.UNKNOWN_KIND | Kind.Unrecognized(_) => ()
+    }
+    if (x.name.nonEmpty) {
+      p.str(x.name)
+    } else {
+      p.str("<?>")
+    }
+    x.kind match {
+      case k.LOCAL | k.FIELD | k.METHOD | k.CONSTRUCTOR | k.MACRO | k.TYPE |
+          k.PARAMETER | k.SELF_PARAMETER | k.TYPE_PARAMETER =>
+        x.tpe match {
+          case Some(tpe) =>
+            p.str(": ")
+            p.str(tpe)
+          case None =>
+            p.str(": <?>")
+        }
+      case k.OBJECT | k.PACKAGE_OBJECT | k.CLASS | k.TRAIT | k.INTERFACE =>
+        x.tpe.flatMap(_.classInfoType) match {
+          case Some(ClassInfoType(tparams, parents, decls)) =>
+            // TODO: Implement me.
+            p.rep("[", tparams, ", ", "]")(sym => p.str("<" + sym + ">"))
+            p.rep("extends ", parents, " with ")(parent => p.str(parent))
+            p.str(s" {+${decls.length} decls}")
+          case None =>
+            p.str(": <?>")
+        }
+      case k.PACKAGE | k.UNKNOWN_KIND | Kind.Unrecognized(_) =>
+        ()
+    }
+  }
+
+  def repl(p: Printer, x: SymbolInformation): Unit = {
+    // TODO: Implement me.
+    p.str(x.toProtoString)
+  }
+}

--- a/rsc/src/main/scala/rsc/pretty/PrettySymtabInfo.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySymtabInfo.scala
@@ -29,6 +29,7 @@ object PrettySymtabInfo {
     if (has(Property.VAR)) p.str("var ")
     if (has(Property.STATIC)) p.str("static ")
     if (has(Property.PRIMARY)) p.str("primary ")
+    if (has(Property.ENUM)) p.str("enum ")
     x.kind match {
       case k.LOCAL => p.str("local ")
       case k.FIELD => p.str("field ")
@@ -65,7 +66,6 @@ object PrettySymtabInfo {
       case k.OBJECT | k.PACKAGE_OBJECT | k.CLASS | k.TRAIT | k.INTERFACE =>
         x.tpe.flatMap(_.classInfoType) match {
           case Some(ClassInfoType(tparams, parents, decls)) =>
-            // TODO: Implement me.
             p.rep("[", tparams, ", ", "]")(sym => p.str("<" + sym + ">"))
             p.rep("extends ", parents, " with ")(parent => p.str(parent))
             p.str(s" {+${decls.length} decls}")
@@ -78,7 +78,6 @@ object PrettySymtabInfo {
   }
 
   def repl(p: Printer, x: SymbolInformation): Unit = {
-    // TODO: Implement me.
     p.str(x.toProtoString)
   }
 }

--- a/rsc/src/main/scala/rsc/pretty/PrettySymtabSymtab.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySymtabSymtab.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.pretty
+
+import scala.collection.JavaConverters._
+import rsc.symtab._
+import rsc.util._
+
+object PrettySymtabSymtab {
+  def str(p: Printer, x: Symtab): Unit = {
+    p.header("Scopes (symtab)")
+    p.str(x._scopes)
+    p.newline()
+    p.header("Infos (symtab)")
+    p.str(x._infos)
+  }
+
+  def str[T: Str](p: Printer, x: Symtab#Table[T]): Unit = {
+    val entries = x._storage.asScala.toList.sortBy(_._1.str)
+    p.rep(entries, EOL) {
+      case (_, entry) =>
+        p.str(entry)
+    }
+    if (entries.nonEmpty) {
+      p.newline()
+    }
+  }
+
+  def repl(p: Printer, x: Symtab): Unit = {
+    crash(x)
+  }
+
+  def repl[T: Repl](p: Printer, x: Symtab#Table[T]): Unit = {
+    crash(x)
+  }
+}

--- a/rsc/src/main/scala/rsc/pretty/PrettySymtabType.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySymtabType.scala
@@ -12,7 +12,6 @@ object PrettySymtabType {
       p.str("<" + sym + ">")
     }
     def defn(sym: String): Unit = {
-      // TODO: Implement me.
       ref(sym)
     }
     def prefix(x: Type): Unit = {
@@ -146,7 +145,6 @@ object PrettySymtabType {
   }
 
   def repl(p: Printer, x: Type): Unit = {
-    // TODO: Implement me.
     p.str(x.toProtoString)
   }
 }

--- a/rsc/src/main/scala/rsc/pretty/PrettySymtabType.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySymtabType.scala
@@ -1,0 +1,152 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.pretty
+
+import scala.meta.internal.semanticdb3._
+import scala.meta.internal.semanticdb3.SingletonType.Tag._
+import scala.meta.internal.semanticdb3.Type.Tag._
+
+object PrettySymtabType {
+  def str(p: Printer, x: Type): Unit = {
+    def ref(sym: String): Unit = {
+      p.str("<" + sym + ">")
+    }
+    def defn(sym: String): Unit = {
+      // TODO: Implement me.
+      ref(sym)
+    }
+    def prefix(x: Type): Unit = {
+      x.tag match {
+        case TYPE_REF =>
+          val Some(TypeRef(pre, sym, args)) = x.typeRef
+          pre match {
+            case Some(pre) if pre.tag.isSingletonType =>
+              prefix(pre)
+              p.str(".")
+            case Some(pre) =>
+              prefix(pre)
+              p.str("#")
+            case _ =>
+              ()
+          }
+          ref(sym)
+          p.rep("[", args, ", ", "]")(normal)
+        case SINGLETON_TYPE =>
+          val Some(SingletonType(tag, pre, sym, prim, s)) = x.singletonType
+          tag match {
+            case SYMBOL =>
+              p.opt(pre, ".")(prefix)
+              ref(sym)
+            case THIS =>
+              p.opt(sym, ".")(ref)
+              p.str("this")
+            case SUPER =>
+              p.opt(pre, ".")(prefix)
+              p.str("super")
+              p.opt("[", sym, "]")(ref)
+            case UNIT =>
+              p.str("()")
+            case BOOLEAN =>
+              if (prim == 0) p.str("false")
+              else if (prim == 1) p.str("true")
+              else p.str("<?>")
+            case BYTE | SHORT =>
+              p.str(prim)
+            case CHAR =>
+              p.str("'" + prim.toChar + "'")
+            case INT =>
+              p.repl(prim.toInt)
+            case LONG =>
+              p.repl(prim.toLong)
+            case FLOAT =>
+              p.str(java.lang.Float.intBitsToFloat(prim.toInt) + "f")
+            case DOUBLE =>
+              p.str(java.lang.Double.longBitsToDouble(prim.toLong))
+            case STRING =>
+              p.repl(s)
+            case NULL =>
+              p.str("null")
+            case UNKNOWN_SINGLETON | SingletonType.Tag.Unrecognized(_) =>
+              p.str("<?>")
+          }
+        case INTERSECTION_TYPE =>
+          val Some(IntersectionType(types)) = x.intersectionType
+          p.rep(types, " & ")(normal)
+        case UNION_TYPE =>
+          val Some(UnionType(types)) = x.unionType
+          p.rep(types, " | ")(normal)
+        case WITH_TYPE =>
+          val Some(WithType(types)) = x.withType
+          p.rep(types, " with ")(normal)
+        case STRUCTURAL_TYPE =>
+          val Some(StructuralType(utpe, decls)) = x.structuralType
+          utpe.foreach(normal)
+          p.rep(" {", decls, "; ", " }")(defn)
+        case ANNOTATED_TYPE =>
+          val Some(AnnotatedType(anns, utpe)) = x.annotatedType
+          utpe.foreach(normal)
+          p.str(" ")
+          p.rep(anns, " ", "")(ann => p.str(ann))
+        case EXISTENTIAL_TYPE =>
+          val Some(ExistentialType(tparams, utpe)) = x.existentialType
+          utpe.foreach(normal)
+          p.rep(" forSome { ", tparams, "; ", " }")(defn)
+        case UNIVERSAL_TYPE =>
+          val Some(UniversalType(tparams, utpe)) = x.universalType
+          p.rep("[", tparams, ", ", "] => ")(defn)
+          utpe.foreach(normal)
+        case CLASS_INFO_TYPE =>
+          val Some(ClassInfoType(tparams, parents, decls)) = x.classInfoType
+          p.rep("[", tparams, ", ", "] => ")(defn)
+          p.rep(parents, " with ")(normal)
+          p.rep(" { ", decls, "; ", " }")(defn)
+        case METHOD_TYPE =>
+          val Some(MethodType(tparams, paramss, res)) = x.methodType
+          p.rep("[", tparams, ", ", "] => ")(defn)
+          p.rep("(", paramss, ")(", ")") { params =>
+            p.rep(params.symbols, ", ")(defn)
+          }
+          p.str(": ")
+          res.foreach(normal)
+        case BY_NAME_TYPE =>
+          val Some(ByNameType(utpe)) = x.byNameType
+          p.str("=> ")
+          utpe.foreach(normal)
+        case REPEATED_TYPE =>
+          val Some(RepeatedType(utpe)) = x.repeatedType
+          utpe.foreach(normal)
+          p.str("*")
+        case TYPE_TYPE =>
+          val Some(TypeType(tparams, lo, hi)) = x.typeType
+          p.rep("[", tparams, ", ", "] => ")(defn)
+          p.opt(">: ", lo, "")(normal)
+          lo.foreach(_ => p.str(" "))
+          p.opt("<: ", hi, "")(normal)
+        case UNKNOWN_TYPE | Type.Tag.Unrecognized(_) =>
+          p.str("<?>")
+      }
+    }
+    def normal(x: Type): Unit = {
+      x.tag match {
+        case SINGLETON_TYPE =>
+          val Some(SingletonType(tag, _, _, _, _)) = x.singletonType
+          tag match {
+            case SYMBOL | THIS | SUPER =>
+              prefix(x)
+              p.str(".type")
+            case _ =>
+              prefix(x)
+          }
+        case _ =>
+          prefix(x)
+      }
+    }
+    if (x != null) normal(x)
+    else p.str("ø")
+  }
+
+  def repl(p: Printer, x: Type): Unit = {
+    // TODO: Implement me.
+    p.str(x.toProtoString)
+  }
+}

--- a/rsc/src/main/scala/rsc/pretty/PrettyTypecheckSymtab.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyTypecheckSymtab.scala
@@ -6,7 +6,7 @@ import scala.collection.JavaConverters._
 import rsc.typecheck._
 import rsc.util._
 
-object PrettySymtab {
+object PrettyTypecheckSymtab {
   def str(p: Printer, x: Symtab): Unit = {
     p.header("Scopes (symtab)")
     val scopes = x._scopes.asScala.toList.sortBy(_._1.str)

--- a/rsc/src/main/scala/rsc/pretty/Printer.scala
+++ b/rsc/src/main/scala/rsc/pretty/Printer.scala
@@ -42,6 +42,23 @@ final class Printer {
     else str("null")
   }
 
+  def rep[T](pre: String, xs: Iterable[T], sep: String, suf: String)(
+      f: T => Unit): Unit = {
+    if (xs.nonEmpty) {
+      append(pre)
+      rep(xs, sep)(f)
+      append(suf)
+    }
+  }
+
+  def rep[T](pre: String, xs: Iterable[T], sep: String)(f: T => Unit): Unit = {
+    rep(pre, xs, sep, "")(f)
+  }
+
+  def rep[T](xs: Iterable[T], sep: String, suf: String)(f: T => Unit): Unit = {
+    rep("", xs, sep, suf)(f)
+  }
+
   def rep[T](xs: Iterable[T], sep: String)(f: T => Unit): Unit = {
     if (xs.nonEmpty) {
       xs.init.foreach { x =>
@@ -50,6 +67,42 @@ final class Printer {
       }
       f(xs.last)
     }
+  }
+
+  def opt[T](pre: String, xs: Option[T], suf: String)(f: T => Unit): Unit = {
+    xs.foreach { x =>
+      append(pre)
+      f(x)
+      append(suf)
+    }
+  }
+
+  def opt[T](pre: String, xs: Option[T])(f: T => Unit): Unit = {
+    opt(pre, xs, "")(f)
+  }
+
+  def opt[T](xs: Option[T], suf: String)(f: T => Unit): Unit = {
+    opt("", xs, suf)(f)
+  }
+
+  def opt[T](xs: Option[T])(f: T => Unit): Unit = {
+    opt("", xs, "")(f)
+  }
+
+  def opt(pre: String, s: String, suf: String)(f: String => Unit): Unit = {
+    if (s.nonEmpty) {
+      append(pre)
+      f(s)
+      append(suf)
+    }
+  }
+
+  def opt(s: String, suf: String)(f: String => Unit): Unit = {
+    opt("", s, suf)(f)
+  }
+
+  def opt(s: String)(f: String => Unit): Unit = {
+    opt("", s, "")(f)
   }
 
   def indent(n: Int = 1): Unit = {

--- a/rsc/src/main/scala/rsc/pretty/package.scala
+++ b/rsc/src/main/scala/rsc/pretty/package.scala
@@ -2,6 +2,6 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc
 
-package object pretty extends Ops {
+package object pretty extends Instances with Ops {
   val EOL = System.lineSeparator()
 }

--- a/rsc/src/main/scala/rsc/semantics/Names.scala
+++ b/rsc/src/main/scala/rsc/semantics/Names.scala
@@ -10,6 +10,14 @@ sealed trait Name extends Pretty with Product {
   def printRepl(p: Printer): Unit = PrettyName.repl(p, this)
 }
 
+object Name {
+  def apply(str: String): Name = {
+    if (str.endsWith(".")) TermName(str.substring(0, str.length - 1))
+    else if (str.endsWith("#")) TypeName(str.substring(0, str.length - 1))
+    else SomeName(str)
+  }
+}
+
 final case class SomeName(value: String) extends Name {
   override val hashCode: Int = value.hashCode * 3
   override def str: String = value

--- a/rsc/src/main/scala/rsc/semantics/Types.scala
+++ b/rsc/src/main/scala/rsc/semantics/Types.scala
@@ -5,8 +5,8 @@ package rsc.semantics
 import rsc.pretty._
 
 sealed trait Type extends Pretty with Product {
-  def printStr(p: Printer): Unit = PrettyType.str(p, this)
-  def printRepl(p: Printer): Unit = PrettyType.repl(p, this)
+  def printStr(p: Printer): Unit = PrettySemanticType.str(p, this)
+  def printRepl(p: Printer): Unit = PrettySemanticType.repl(p, this)
 }
 
 final case object NoType extends Type

--- a/rsc/src/main/scala/rsc/symtab/Loaders.scala
+++ b/rsc/src/main/scala/rsc/symtab/Loaders.scala
@@ -1,0 +1,119 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.symtab
+
+import java.nio.file._
+import java.util.jar._
+import java.util.HashMap
+import scala.meta.internal.semanticdb3._
+import scala.meta.internal.semanticdb3.{Language => l}
+import scala.meta.internal.semanticdb3.Scala._
+import scala.meta.internal.semanticdb3.SymbolInformation.{Kind => k}
+import rsc.semantics._
+import rsc.typecheck._
+import rsc.util._
+
+trait Loaders {
+  self: Symtab =>
+
+  private val todo = new HashMap[Symbol, SemanticdbFile]
+
+  // TODO: I would've used URL instead of a custom ADT,
+  // but Scala Native doesn't suppport URL.openStream.
+  // It also doesn't support ZipFileSystemProvider, for that matter.
+  private sealed trait SemanticdbFile
+  private case class Uncompressed(dir: Path, rel: String) extends SemanticdbFile
+  private case class Compressed(jar: Path, rel: String) extends SemanticdbFile
+
+  protected def scanClasspath(classpath: List[Path]): Unit = {
+    val packages = List.newBuilder[Scope]
+    classpath.foreach { entryPath =>
+      def consumeIndex(index: Index): Unit = {
+        index.packages.foreach { p =>
+          var scope = _scopes._storage.get(p.symbol)
+          if (scope == null) {
+            scope = PackageScope(p.symbol)
+            packages += scope
+            _scopes._storage.put(p.symbol, scope)
+            val info = SymbolInformation(
+              symbol = p.symbol,
+              language = l.SCALA,
+              kind = k.PACKAGE,
+              name = p.symbol.desc.name,
+              owner = p.symbol.owner
+            )
+            _infos._storage.put(p.symbol, info)
+          }
+          p.members.foreach { m =>
+            val name = Name(m.desc.toString)
+            val m1 = scope.enter(name, m)
+            if (m1 != NoSymbol && m1 != m) crash(m)
+          }
+        }
+        index.toplevels.foreach { t =>
+          val semanticdbFile = {
+            if (Files.isDirectory(entryPath)) {
+              Uncompressed(entryPath, "META-INF/semanticdb/" + t.uri)
+            } else if (entryPath.toString.endsWith(".jar")) {
+              Compressed(entryPath, "META-INF/semanticdb/" + t.uri)
+            } else {
+              crash(entryPath.toString)
+            }
+          }
+          todo.put(t.symbol, semanticdbFile)
+        }
+      }
+      if (Files.isDirectory(entryPath)) {
+        val indexPath = entryPath.resolve("META-INF/semanticdb.semanticidx")
+        if (Files.exists(indexPath)) {
+          val indexStream = Files.newInputStream(indexPath)
+          try consumeIndex(Index.parseFrom(indexStream))
+          finally indexStream.close()
+        }
+      } else if (entryPath.toString.endsWith(".jar")) {
+        val jar = new JarFile(entryPath.toFile)
+        val indexEntry = jar.getEntry("META-INF/semanticdb.semanticidx")
+        if (indexEntry != null) {
+          val indexStream = jar.getInputStream(indexEntry)
+          try consumeIndex(Index.parseFrom(indexStream))
+          finally indexStream.close()
+        }
+      } else {
+        ()
+      }
+    }
+    packages.result.foreach(_.succeed())
+  }
+
+  protected def loadFromClasspath(sym: Symbol): Unit = {
+    val semanticdbFile = todo.get(sym)
+    if (semanticdbFile != null) {
+      val semanticdb = {
+        val semanticdbStream = {
+          semanticdbFile match {
+            case Uncompressed(dir, rel) =>
+              Files.newInputStream(dir.resolve(rel))
+            case Compressed(jar, rel) =>
+              val jarFile = new JarFile(jar.toFile)
+              val jarEntry = jarFile.getEntry(rel)
+              jarFile.getInputStream(jarEntry)
+          }
+        }
+        try TextDocuments.parseFrom(semanticdbStream)
+        finally semanticdbStream.close()
+      }
+      val infos = semanticdb.documents.flatMap(_.symbols)
+      infos.foreach { info =>
+        info.kind match {
+          case k.OBJECT | k.PACKAGE_OBJECT | k.CLASS | k.TRAIT | k.INTERFACE =>
+            val scope = SemanticdbScope(info, this)
+            _scopes._storage.put(info.symbol, scope)
+          case _ =>
+            ()
+        }
+        _infos._storage.put(info.symbol, info)
+      }
+      todo.remove(sym)
+    }
+  }
+}

--- a/rsc/src/main/scala/rsc/symtab/Loaders.scala
+++ b/rsc/src/main/scala/rsc/symtab/Loaders.scala
@@ -18,7 +18,7 @@ trait Loaders {
 
   private val todo = new HashMap[Symbol, SemanticdbFile]
 
-  // TODO: I would've used URL instead of a custom ADT,
+  // NOTE: I would've used URL instead of a custom ADT,
   // but Scala Native doesn't suppport URL.openStream.
   // It also doesn't support ZipFileSystemProvider, for that matter.
   private sealed trait SemanticdbFile

--- a/rsc/src/main/scala/rsc/symtab/Symtab.scala
+++ b/rsc/src/main/scala/rsc/symtab/Symtab.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.symtab
+
+import scala.meta.internal.semanticdb3._
+import rsc.pretty._
+import rsc.semantics._
+import rsc.settings._
+import rsc.typecheck._
+
+final class Symtab private (settings: Settings)
+    extends Loaders
+    with Pretty
+    with Tables {
+  scanClasspath(settings.classpath)
+
+  object scopes {
+    def apply(sym: Symbol): Scope = _scopes.apply(sym)
+    def contains(sym: Symbol): Boolean = _scopes.contains(sym)
+    def update(sym: Symbol, scope: Scope): Unit = _scopes.update(sym, scope)
+  }
+
+  object infos {
+    def apply(sym: Symbol): SymbolInformation = _infos.apply(sym)
+    def contains(sym: Symbol): Boolean = _infos.contains(sym)
+    def update(sym: Symbol, info: SymbolInformation) = _infos.update(sym, info)
+  }
+
+  def printStr(p: Printer): Unit = PrettySymtabSymtab.str(p, this)
+  def printRepl(p: Printer): Unit = PrettySymtabSymtab.repl(p, this)
+}
+
+object Symtab {
+  def apply(settings: Settings): Symtab = {
+    new Symtab(settings)
+  }
+}

--- a/rsc/src/main/scala/rsc/symtab/Tables.scala
+++ b/rsc/src/main/scala/rsc/symtab/Tables.scala
@@ -1,0 +1,66 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.symtab
+
+import java.util.HashMap
+import scala.meta.internal.semanticdb3._
+import scala.meta.internal.semanticdb3.Scala._
+import rsc.pretty._
+import rsc.semantics._
+import rsc.typecheck._
+import rsc.util._
+
+trait Tables {
+  self: Symtab =>
+
+  val _scopes = new Table[Scope]
+  val _infos = new Table[SymbolInformation]
+
+  class Table[T: Str: Repl] extends Pretty {
+    val _storage = new HashMap[Symbol, T]
+
+    private def load(sym: Symbol): T = {
+      var payload = _storage.get(sym)
+      if (payload == null) {
+        loadFromClasspath(sym)
+        payload = _storage.get(sym)
+        if (payload == null && sym.owner != NoSymbol) {
+          load(sym.owner)
+          payload = _storage.get(sym)
+        }
+      }
+      payload
+    }
+
+    def apply(sym: Symbol): T = {
+      val payload = load(sym)
+      if (payload == null) {
+        crash(sym)
+      }
+      payload
+    }
+
+    def contains(sym: Symbol): Boolean = {
+      val payload = load(sym)
+      payload != null
+    }
+
+    def update(sym: Symbol, payload: T): Unit = {
+      if (_storage.containsKey(sym)) {
+        crash(sym)
+      }
+      sym match {
+        case NoSymbol => crash(payload)
+        case other => _storage.put(other, payload)
+      }
+    }
+
+    def printStr(p: Printer): Unit = {
+      PrettySymtabSymtab.str(p, this)
+    }
+
+    def printRepl(p: Printer): Unit = {
+      PrettySymtabSymtab.repl(p, this)
+    }
+  }
+}

--- a/rsc/src/main/scala/rsc/typecheck/Scoper.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Scoper.scala
@@ -26,6 +26,8 @@ final class Scoper private (
         scope.succeed()
       case scope: TemplateScope =>
         trySucceed(env, scope)
+      case scope: SemanticdbScope =>
+        crash(scope)
       case scope: SuperScope =>
         crash(scope)
     }

--- a/rsc/src/main/scala/rsc/typecheck/Symtab.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Symtab.scala
@@ -53,11 +53,11 @@ final class Symtab private extends Pretty {
   }
 
   def printStr(p: Printer): Unit = {
-    PrettySymtab.str(p, this)
+    PrettyTypecheckSymtab.str(p, this)
   }
 
   def printRepl(p: Printer): Unit = {
-    PrettySymtab.repl(p, this)
+    PrettyTypecheckSymtab.repl(p, this)
   }
 }
 

--- a/rsc/src/main/scala/rsc/util/ErrorUtil.scala
+++ b/rsc/src/main/scala/rsc/util/ErrorUtil.scala
@@ -18,10 +18,6 @@ trait ErrorUtil {
     throw CrashException(message("crash", x))
   }
 
-  def crash(): Nothing = {
-    throw CrashException("crash")
-  }
-
   private def message[T: Str: Repl](summary: String, culprit: T): String = {
     def safe(fn: => String): String = {
       try fn

--- a/rsc/src/main/scala/rsc/util/ErrorUtil.scala
+++ b/rsc/src/main/scala/rsc/util/ErrorUtil.scala
@@ -18,6 +18,10 @@ trait ErrorUtil {
     throw CrashException(message("crash", x))
   }
 
+  def crash(): Nothing = {
+    throw CrashException("crash")
+  }
+
   private def message[T: Str: Repl](summary: String, culprit: T): String = {
     def safe(fn: => String): String = {
       try fn

--- a/tests/src/main/scala/rsc/tests/FileFixtures.scala
+++ b/tests/src/main/scala/rsc/tests/FileFixtures.scala
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.tests
 
+import java.io.File.pathSeparatorChar
 import java.nio.file._
 import scala.collection.JavaConverters._
+import sys.process._
 
 trait FileFixtures {
   lazy val buildRoot: Path = {
@@ -29,10 +31,43 @@ trait FileFixtures {
   }
 
   lazy val re2sRscFiles: List[Path] = {
-    re2sScalacFiles :+ stdlibPath
+    re2sScalacFiles :+ stdlibSourcepath
   }
 
-  lazy val stdlibPath: Path = {
+  lazy val stdlibSourcepath: Path = {
     buildRoot.resolve("stdlib/src/main/scala/Stdlib.scala")
+  }
+
+  lazy val stdlibClasspath: List[Path] = {
+    val staging = "https://oss.sonatype.org/content/repositories/staging"
+    def fetch(artifact: String): Path = {
+      val command = s"coursier fetch $artifact -r $staging"
+      // println(s"Fetching $artifact...")
+      val stdout = command.!!.trim
+      Paths.get(stdout.split("\n").last)
+    }
+    def detectJdk(): List[Path] = {
+      // println("Detecting JDK...")
+      val bootcp = sys.props.collectFirst {
+        case (k, v) if k.endsWith(".boot.class.path") =>
+          v.split(pathSeparatorChar).toList.map(e => Paths.get(e))
+      }
+      bootcp.getOrElse(sys.error("failed to detect JDK"))
+    }
+    def downloadScalalib(): List[Path] = {
+      List(fetch(BuildInfo.scalaLibraryArtifact))
+    }
+    def metacp(entries: List[Path]): List[Path] = {
+      // NOTE: Can't use Metacp.process here, because metacp is JVM-only.
+      val classpath = entries.mkString(java.io.File.pathSeparator)
+      val metacp = BuildInfo.metacpArtifact
+      val args = s"--include-scala-library-synthetics $classpath"
+      val command = s"coursier launch $metacp -r $staging -- $args"
+      // println(s"Converting $classpath...")
+      val mentries = command.!!.trim.split(pathSeparatorChar).toList
+      mentries.map(me => Paths.get(me))
+    }
+    val classpath = detectJdk() ++ downloadScalalib()
+    metacp(classpath)
   }
 }

--- a/tests/src/main/scala/rsc/tests/FileFixtures.scala
+++ b/tests/src/main/scala/rsc/tests/FileFixtures.scala
@@ -5,7 +5,6 @@ package rsc.tests
 import java.io.File.pathSeparatorChar
 import java.nio.file._
 import scala.collection.JavaConverters._
-import sys.process._
 
 trait FileFixtures {
   lazy val buildRoot: Path = {
@@ -39,35 +38,7 @@ trait FileFixtures {
   }
 
   lazy val stdlibClasspath: List[Path] = {
-    val staging = "https://oss.sonatype.org/content/repositories/staging"
-    def fetch(artifact: String): Path = {
-      val command = s"coursier fetch $artifact -r $staging"
-      // println(s"Fetching $artifact...")
-      val stdout = command.!!.trim
-      Paths.get(stdout.split("\n").last)
-    }
-    def detectJdk(): List[Path] = {
-      // println("Detecting JDK...")
-      val bootcp = sys.props.collectFirst {
-        case (k, v) if k.endsWith(".boot.class.path") =>
-          v.split(pathSeparatorChar).toList.map(e => Paths.get(e))
-      }
-      bootcp.getOrElse(sys.error("failed to detect JDK"))
-    }
-    def downloadScalalib(): List[Path] = {
-      List(fetch(BuildInfo.scalaLibraryArtifact))
-    }
-    def metacp(entries: List[Path]): List[Path] = {
-      // NOTE: Can't use Metacp.process here, because metacp is JVM-only.
-      val classpath = entries.mkString(java.io.File.pathSeparator)
-      val metacp = BuildInfo.metacpArtifact
-      val args = s"--include-scala-library-synthetics $classpath"
-      val command = s"coursier launch $metacp -r $staging -- $args"
-      // println(s"Converting $classpath...")
-      val mentries = command.!!.trim.split(pathSeparatorChar).toList
-      mentries.map(me => Paths.get(me))
-    }
-    val classpath = detectJdk() ++ downloadScalalib()
-    metacp(classpath)
+    val entries = BuildInfo.stdlibClasspath.split(pathSeparatorChar).toList
+    entries.map(e => Paths.get(e))
   }
 }

--- a/tests/src/test/scala/rsc/symtab/SymtabTests.scala
+++ b/tests/src/test/scala/rsc/symtab/SymtabTests.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.symtab
+
+import scala.compat.Platform.EOL
+import scala.meta.internal.semanticdb3.SymbolInformation.{Kind => k}
+import scala.meta.internal.semanticdb3.SymbolInformation.{Property => p}
+import utest._
+import rsc.settings._
+import rsc.tests._
+
+object SymtabTests extends RscTests {
+  var symtab: Symtab = null
+  val tests = Tests {
+    "initialize" - {
+      val settings = Settings(classpath = stdlibClasspath)
+      symtab = Symtab(settings)
+    }
+    "infos(scala.Int#)" - {
+      val int = symtab.infos("scala.Int#")
+      assert(int.kind == k.CLASS)
+      assert(int.properties == (p.ABSTRACT.value | p.FINAL.value))
+    }
+    "members(scala.sys.Prop#)" - {
+      val scope = symtab.scopes("scala.sys.Prop#")
+      val obtained = scope.members.mkString(EOL)
+      assert(obtained == """
+        |scala.sys.Prop#key().
+        |scala.sys.Prop#value().
+        |scala.sys.Prop#[T]
+        |scala.sys.Prop#isSet().
+        |scala.sys.Prop#set(String).
+        |scala.sys.Prop#setValue(T1).
+        |scala.sys.Prop#get().
+        |scala.sys.Prop#option().
+        |scala.sys.Prop#clear().
+        |scala.sys.Prop#zero().
+        |scala.AnyRef#`<init>`().
+        |scala.AnyRef#eq(AnyRef).
+        |scala.AnyRef#ne(AnyRef).
+        |scala.AnyRef#synchronized(T).
+        |scala.Any#`<init>`().
+        |scala.Any#equals(Any).
+        |scala.Any#`==`(Any).
+        |scala.Any#`!=`(Any).
+        |scala.Any#hashCode().
+        |scala.Any#`##`().
+        |scala.Any#toString().
+        |scala.Any#getClass().
+        |scala.Any#isInstanceOf().
+        |scala.Any#asInstanceOf().
+      """.trim.stripMargin)
+    }
+    "infos(java.util.Queue#)" - {
+      val queue = symtab.infos("java.util.Queue#")
+      assert(queue.kind == k.INTERFACE)
+      assert(queue.properties == p.ABSTRACT.value)
+    }
+    "scopes(java.util.Queue#)" - {
+      assert(symtab.scopes("java.util.Queue#") != null)
+    }
+    "members(scala.util.control.NoStackTrace#)" - {
+      val scope = symtab.scopes("scala.util.control.NoStackTrace#")
+      val obtained = scope.members.mkString(EOL)
+      assert(obtained.nonEmpty)
+    }
+  }
+}


### PR DESCRIPTION
This PR adds another implementation of a symbol table to Rsc.
This one is based solely on SemanticDB data structures and, as a result,
can interoperate with binary dependencies preprocessed by metacp.

In order to make sure that we're aware of performance implications,
I'm not replacing the old symbol table with the new one right away.
Instead, I'm planning to turn this into a set of small steps, with
every step carefully benchmarked.

This gradual process will require some additional ceremony during
the transition period while both symbol tables coexist. I think this
is well-justified given the benefits of iterative development that
the transition period will enable.