### PR TITLE
Implement PackageScope.members

### DIFF
--- a/rsc/src/main/scala/rsc/pretty/PrettySymtabScope.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettySymtabScope.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.pretty
+
+import scala.meta.internal.semanticdb3._
+import rsc.symtab._
+import rsc.util._
+
+object PrettySymtabScope {
+  def str(p: Printer, x: Scope): Unit = {
+    p.str(x.sym)
+    x match {
+      case x: PackageScope =>
+        p.str(" [")
+        val storage = x._storage.toList.sortBy(_._1.str)
+        p.rep(storage.map(_._2), ", ")(p.str)
+        p.str("]")
+      case x: TemplateScope =>
+        x.info.tpe.flatMap(_.classInfoType) match {
+          case Some(ClassInfoType(_, parents, _)) =>
+            p.str(" ")
+            p.rep(parents, " with ")(parent => p.str(parent))
+          case None =>
+            crash(x.info)
+        }
+        if (x._storage != null) {
+          p.str(" [")
+          val storage = x._storage.toList.sortBy(_._1.str)
+          p.rep(storage.map(_._2), ", ")(p.str)
+          p.str("]")
+        } else {
+          x.info.tpe.flatMap(_.classInfoType) match {
+            case Some(ClassInfoType(_, _, decls)) =>
+              p.str(s" {+${decls.length} decls}")
+            case None =>
+              crash(x.info)
+          }
+        }
+    }
+  }
+
+  def repl(p: Printer, x: Scope): Unit = {
+    crash(x)
+  }
+}

--- a/rsc/src/main/scala/rsc/pretty/PrettyTypecheckScope.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyTypecheckScope.scala
@@ -3,11 +3,10 @@
 package rsc.pretty
 
 import scala.collection.JavaConverters._
-import scala.meta.internal.{semanticdb3 => s}
 import rsc.typecheck._
 import rsc.util._
 
-object PrettyScope {
+object PrettyTypecheckScope {
   def str(p: Printer, x: Scope): Unit = {
     p.str(x.sym)
     p.str(" ")
@@ -20,14 +19,6 @@ object PrettyScope {
         case x: TemplateScope =>
           p.str(" ")
           p.rep(x.parents, " with ")(scope => p.str(scope.sym))
-        case x: SemanticdbScope =>
-          x.info.tpe.flatMap(_.classInfoType) match {
-            case Some(s.ClassInfoType(_, parents, _)) =>
-              p.str(" ")
-              p.rep(parents, " with ")(parent => p.str(parent))
-            case None =>
-              crash(x.info)
-          }
         case x: SuperScope =>
           p.str(" ")
           p.rep(x.underlying.parents, " with ")(scope => p.str(scope.sym))
@@ -41,20 +32,6 @@ object PrettyScope {
         val storage = x._storage.asScala.toList.sortBy(_._1.str)
         p.rep(storage.map(_._2), ", ")(p.str)
         p.str("]")
-      case x: SemanticdbScope =>
-        if (x._storage != null) {
-          p.str(" [")
-          val storage = x._storage.asScala.toList.sortBy(_._1.str)
-          p.rep(storage.map(_._2), ", ")(p.str)
-          p.str("]")
-        } else {
-          x.info.tpe.flatMap(_.classInfoType) match {
-            case Some(s.ClassInfoType(_, _, decls)) =>
-              p.str(s" {+${decls.length} decls}")
-            case None =>
-              crash(x.info)
-          }
-        }
       case _ =>
         ()
     }

--- a/rsc/src/main/scala/rsc/symtab/Scopes.scala
+++ b/rsc/src/main/scala/rsc/symtab/Scopes.scala
@@ -1,0 +1,108 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.symtab
+
+import scala.collection.mutable
+import scala.meta.internal.semanticdb3._
+import scala.meta.internal.{semanticdb3 => s}
+import scala.meta.internal.semanticdb3.Scala._
+import scala.meta.internal.semanticdb3.SymbolInformation.{Kind => k}
+import scala.meta.internal.semanticdb3.Type.{Tag => t}
+import rsc.pretty._
+import rsc.semantics._
+import rsc.util._
+
+sealed abstract class Scope(val sym: Symbol) extends Pretty {
+  def lookup(name: Name): Symbol
+  def members: Iterator[Symbol]
+  override def printStr(p: Printer): Unit = PrettySymtabScope.str(p, this)
+  override def printRepl(p: Printer): Unit = PrettySymtabScope.repl(p, this)
+}
+
+final class PackageScope private (sym: Symbol) extends Scope(sym) {
+  val _storage = new mutable.LinkedHashMap[Name, Symbol]
+
+  override def lookup(name: Name): Symbol = {
+    _storage.getOrElse(name, NoSymbol)
+  }
+
+  override def members: Iterator[Symbol] = {
+    _storage.valuesIterator
+  }
+}
+
+object PackageScope {
+  def apply(sym: Symbol) = {
+    new PackageScope(sym)
+  }
+}
+
+final class TemplateScope private (
+    val info: SymbolInformation,
+    val symtab: Symtab)
+    extends Scope(info.symbol) {
+  var _storage: mutable.LinkedHashMap[Name, Symbol] = null
+  var _parents: mutable.UnrolledBuffer[TemplateScope] = null
+
+  private def loadStorage(): Unit = {
+    info.tpe.flatMap(_.classInfoType) match {
+      case Some(ClassInfoType(_, _, decls)) =>
+        _storage = mutable.LinkedHashMap[Name, Symbol]()
+        decls.foreach(decl => _storage(Name(decl.desc.toString)) = decl)
+      case other =>
+        crash(info)
+    }
+  }
+
+  private def loadParents(): Unit = {
+    info.tpe.flatMap(_.classInfoType) match {
+      case Some(ClassInfoType(_, parents, _)) =>
+        def parentScope(tpe: s.Type): TemplateScope = {
+          if (tpe.tag == t.TYPE_REF) {
+            val Some(TypeRef(_, sym, targs)) = tpe.typeRef
+            val info = symtab.infos(sym)
+            info.kind match {
+              case k.OBJECT | k.PACKAGE_OBJECT | k.CLASS | k.TRAIT |
+                  k.INTERFACE =>
+                TemplateScope(info, symtab)
+              case k.TYPE =>
+                val hi = info.tpe.flatMap(_.typeType.flatMap(_.upperBound)).get
+                parentScope(hi)
+              case _ =>
+                crash(info)
+            }
+          } else {
+            crash(tpe)
+          }
+        }
+        _parents = mutable.UnrolledBuffer[TemplateScope]()
+        parents.map(parentScope).foreach(_parents += _)
+      case other =>
+        crash(info)
+    }
+  }
+
+  override def lookup(name: Name): Symbol = {
+    if (_storage == null) loadStorage()
+    _storage.getOrElse(name, {
+      if (_parents == null) loadParents()
+      var result: Symbol = NoSymbol
+      _parents.foreach(p => if (result == NoSymbol) result = p.lookup(name))
+      result
+    })
+  }
+
+  override def members: Iterator[Symbol] = {
+    if (_storage == null) loadStorage()
+    if (_parents == null) loadParents()
+    val decls = _storage.valuesIterator
+    val inherited = _parents.iterator.flatMap(_.members)
+    decls ++ inherited
+  }
+}
+
+object TemplateScope {
+  def apply(info: SymbolInformation, symtab: Symtab) = {
+    new TemplateScope(info, symtab)
+  }
+}

--- a/rsc/src/main/scala/rsc/symtab/Symtab.scala
+++ b/rsc/src/main/scala/rsc/symtab/Symtab.scala
@@ -6,7 +6,6 @@ import scala.meta.internal.semanticdb3._
 import rsc.pretty._
 import rsc.semantics._
 import rsc.settings._
-import rsc.typecheck._
 
 final class Symtab private (settings: Settings)
     extends Loaders

--- a/rsc/src/main/scala/rsc/symtab/Tables.scala
+++ b/rsc/src/main/scala/rsc/symtab/Tables.scala
@@ -7,7 +7,6 @@ import scala.meta.internal.semanticdb3._
 import scala.meta.internal.semanticdb3.Scala._
 import rsc.pretty._
 import rsc.semantics._
-import rsc.typecheck._
 import rsc.util._
 
 trait Tables {

--- a/rsc/src/main/scala/rsc/typecheck/Scoper.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Scoper.scala
@@ -26,8 +26,6 @@ final class Scoper private (
         scope.succeed()
       case scope: TemplateScope =>
         trySucceed(env, scope)
-      case scope: SemanticdbScope =>
-        crash(scope)
       case scope: SuperScope =>
         crash(scope)
     }

--- a/rsc/src/main/scala/rsc/typecheck/Scopes.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Scopes.scala
@@ -2,13 +2,8 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.typecheck
 
-import java.util.{HashMap, LinkedHashMap, Map}
-import scala.collection.JavaConverters._
+import java.util.{HashMap, Map}
 import scala.collection.mutable
-import scala.meta.internal.{semanticdb3 => s}
-import scala.meta.internal.semanticdb3.Scala._
-import scala.meta.internal.semanticdb3.SymbolInformation.{Kind => k}
-import scala.meta.internal.semanticdb3.Type.{Tag => t}
 import rsc.pretty._
 import rsc.semantics._
 import rsc.syntax._
@@ -20,8 +15,6 @@ sealed abstract class Scope(val sym: Symbol) extends Pretty {
   def enter(name: Name, sym: Symbol): Symbol
 
   def lookup(name: Name): Symbol
-
-  def members: Iterator[Symbol]
 
   def resolve(name: Name): Resolution = {
     status match {
@@ -119,11 +112,11 @@ sealed abstract class Scope(val sym: Symbol) extends Pretty {
   }
 
   override def printStr(p: Printer): Unit = {
-    PrettyScope.str(p, this)
+    PrettyTypecheckScope.str(p, this)
   }
 
   override def printRepl(p: Printer): Unit = {
-    PrettyScope.repl(p, this)
+    PrettyTypecheckScope.repl(p, this)
   }
 }
 
@@ -188,10 +181,6 @@ final class ImporterScope private (sym: Symbol, val tree: Importer)
     }
   }
 
-  override def members: Iterator[Symbol] = {
-    crash(this)
-  }
-
   override def resolve(name: Name): Resolution = {
     val name1 = remap(name)
     if (name1 != null) {
@@ -231,7 +220,7 @@ object ImporterScope {
 }
 
 sealed abstract class OwnerScope(sym: Symbol) extends Scope(sym) {
-  var _storage: Map[Name, Symbol] = new HashMap[Name, Symbol]
+  val _storage: Map[Name, Symbol] = new HashMap[Name, Symbol]
 
   override def enter(name: Name, sym: Symbol): Symbol = {
     if (status.isPending) {
@@ -275,10 +264,6 @@ sealed abstract class OwnerScope(sym: Symbol) extends Scope(sym) {
     }
   }
 
-  override def members: Iterator[Symbol] = {
-    crash(this)
-  }
-
   override def resolve(name: Name): Resolution = {
     if (status.isSucceeded) {
       val result = _storage.get(name)
@@ -307,17 +292,7 @@ object FlatScope {
   }
 }
 
-final class PackageScope private (sym: Symbol) extends OwnerScope(sym) {
-  _storage = new LinkedHashMap[Name, Symbol]
-
-  override def members: Iterator[Symbol] = {
-    if (status.isSucceeded) {
-      _storage.values.iterator.asScala
-    } else {
-      crash(this)
-    }
-  }
-}
+final class PackageScope private (sym: Symbol) extends OwnerScope(sym)
 
 object PackageScope {
   def apply(sym: Symbol): PackageScope = {
@@ -379,117 +354,6 @@ object TemplateScope {
   }
 }
 
-final class SemanticdbScope private (
-    val info: s.SymbolInformation,
-    val symtab: rsc.symtab.Symtab)
-    extends Scope(info.symbol) {
-  status = SucceededStatus
-  var _storage: Map[Name, Symbol] = null
-  var _env: Env = null
-
-  private def loadStorage(): Unit = {
-    info.tpe.flatMap(_.classInfoType) match {
-      case Some(s.ClassInfoType(_, _, decls)) =>
-        _storage = new LinkedHashMap[Name, Symbol]
-        decls.foreach(decl => _storage.put(Name(decl.desc.toString), decl))
-      case other =>
-        crash(info)
-    }
-  }
-
-  private def loadEnv(): Unit = {
-    info.tpe.flatMap(_.classInfoType) match {
-      case Some(s.ClassInfoType(_, parents, _)) =>
-        def parentScope(tpe: s.Type): Scope = {
-          if (tpe.tag == t.TYPE_REF) {
-            val Some(s.TypeRef(_, sym, targs)) = tpe.typeRef
-            val info = symtab.infos(sym)
-            info.kind match {
-              case k.OBJECT | k.PACKAGE_OBJECT | k.CLASS | k.TRAIT |
-                  k.INTERFACE =>
-                SemanticdbScope(info, symtab)
-              case k.TYPE =>
-                val hi = info.tpe.flatMap(_.typeType.flatMap(_.upperBound)).get
-                parentScope(hi)
-              case _ =>
-                crash(info)
-            }
-          } else {
-            crash(tpe)
-          }
-        }
-        _env = Env()
-        parents.foreach(parent => _env = parentScope(parent) :: _env)
-      case other =>
-        crash(info)
-    }
-  }
-
-  override def enter(name: Name, sym: Symbol): Symbol = {
-    crash(this)
-  }
-
-  override def lookup(name: Name): Symbol = {
-    if (_storage == null) loadStorage()
-    val result = _storage.get(name)
-    if (result != null) {
-      result
-    } else {
-      if (_env == null) loadEnv()
-      _env.lookup(name) match {
-        case NoSymbol =>
-          name match {
-            case SomeName(value) =>
-              crash(name)
-            case _ =>
-              NoSymbol
-          }
-        case result =>
-          result
-      }
-    }
-  }
-
-  override def members: Iterator[Symbol] = {
-    if (status.isSucceeded) {
-      if (_storage == null) loadStorage()
-      if (_env == null) loadEnv()
-      val decls = _storage.values.iterator.asScala
-      val inherited = _env._scopes.iterator.flatMap(_.members)
-      decls ++ inherited
-    } else {
-      crash(this)
-    }
-  }
-
-  override def resolve(name: Name): Resolution = {
-    if (_storage == null) loadStorage()
-    val result = _storage.get(name)
-    if (result != null) {
-      FoundResolution(result)
-    } else {
-      if (_env == null) loadEnv()
-      _env.resolve(name) match {
-        case MissingResolution =>
-          name match {
-            case SomeName(value) =>
-              crash(name)
-            case _ =>
-              MissingResolution
-          }
-        case resolution =>
-          resolution
-      }
-    }
-  }
-}
-
-object SemanticdbScope {
-  def apply(info: s.SymbolInformation, symtab: rsc.symtab.Symtab) = {
-    new SemanticdbScope(info, symtab)
-  }
-}
-
 final class SuperScope private (sym: Symbol, val underlying: TemplateScope)
     extends Scope(sym) {
   status = SucceededStatus
@@ -500,10 +364,6 @@ final class SuperScope private (sym: Symbol, val underlying: TemplateScope)
 
   override def lookup(name: Name): Symbol = {
     underlying._env.lookup(name)
-  }
-
-  override def members: Iterator[Symbol] = {
-    crash(this)
   }
 
   override def resolve(name: Name): Resolution = {

--- a/rsc/src/main/scala/rsc/typecheck/Scopes.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Scopes.scala
@@ -231,7 +231,7 @@ object ImporterScope {
 }
 
 sealed abstract class OwnerScope(sym: Symbol) extends Scope(sym) {
-  val _storage: Map[Name, Symbol] = new HashMap[Name, Symbol]
+  var _storage: Map[Name, Symbol] = new HashMap[Name, Symbol]
 
   override def enter(name: Name, sym: Symbol): Symbol = {
     if (status.isPending) {
@@ -307,7 +307,17 @@ object FlatScope {
   }
 }
 
-final class PackageScope private (sym: Symbol) extends OwnerScope(sym)
+final class PackageScope private (sym: Symbol) extends OwnerScope(sym) {
+  _storage = new LinkedHashMap[Name, Symbol]
+
+  override def members: Iterator[Symbol] = {
+    if (status.isSucceeded) {
+      _storage.values.iterator.asScala
+    } else {
+      crash(this)
+    }
+  }
+}
 
 object PackageScope {
   def apply(sym: Symbol): PackageScope = {

--- a/tests/src/test/scala/rsc/symtab/SymtabTests.scala
+++ b/tests/src/test/scala/rsc/symtab/SymtabTests.scala
@@ -64,5 +64,22 @@ object SymtabTests extends RscTests {
       val obtained = scope.members.mkString(EOL)
       assert(obtained.nonEmpty)
     }
+    "members(scala.annotation.meta.)" - {
+      val scope = symtab.scopes("scala.annotation.meta.")
+      val obtained = scope.members.mkString(EOL)
+      assert(obtained == """
+        |scala.annotation.meta.companionObject#
+        |scala.annotation.meta.param#
+        |scala.annotation.meta.beanSetter#
+        |scala.annotation.meta.field#
+        |scala.annotation.meta.getter#
+        |scala.annotation.meta.companionMethod#
+        |scala.annotation.meta.companionClass#
+        |scala.annotation.meta.package.
+        |scala.annotation.meta.setter#
+        |scala.annotation.meta.languageFeature#
+        |scala.annotation.meta.beanGetter#
+      """.trim.stripMargin)
+    }
   }
 }


### PR DESCRIPTION
In addition to providing an implementation for PackageScope.members,
this commit also changes PackageScope._storage to LinkedHashMap
to preserve insertion order.

This doesn't help much at the moment, because semanticdb.semanticidx
is pretty insane (https://github.com/scalameta/scalameta/issues/1457),
but I hope to address that soon.