### PR TITLE
Add a bunch of fixmes

### DIFF
--- a/mjar/mjar/src/main/scala/scala/meta/internal/mjar/Pickle.scala
+++ b/mjar/mjar/src/main/scala/scala/meta/internal/mjar/Pickle.scala
@@ -109,6 +109,7 @@ class Pickle(abi: Abi, symtab: Symtab, sroot1: String, sroot2: String) {
             val thisType = owners.inThisType(ssym.sself.map(emitTpe))
             ClassSymbol(name, owner, flags, within, info, thisType)
           } else if (ssym.isDef || ssym.isParam || ssym.isField) {
+            // FIXME: https://github.com/twitter/rsc/issues/100
             val alias = None
             ValSymbol(name, owner, flags, within, info, alias)
           } else {
@@ -248,8 +249,10 @@ class Pickle(abi: Abi, symtab: Symtab, sroot1: String, sroot2: String) {
           val sym = emitSym(ssym, RefMode)
           ThisType(sym)
         case s.SuperType(spre, ssym) =>
+          // FIXME: https://github.com/twitter/rsc/issues/96
           crash(stpe.toTypeMessage.toProtoString)
         case s.ConstantType(sconst) =>
+          // FIXME: https://github.com/twitter/rsc/issues/118
           crash(stpe.toTypeMessage.toProtoString)
         case stpe @ s.StructuralType(sret, sdecls) =>
           val srefinement = Transients.srefinement(stpe)
@@ -295,6 +298,7 @@ class Pickle(abi: Abi, symtab: Symtab, sroot1: String, sroot2: String) {
 
   private def emitAnnot(sannot: s.Annotation): Ref = {
     entries.getOrElseUpdate(AnnotationKey(sannot)) {
+      // FIXME: https://github.com/twitter/rsc/issues/93
       val tpe = emitTpe(sannot.tpe)
       AnnotInfo(tpe, Nil)
     }
@@ -377,6 +381,7 @@ class Pickle(abi: Abi, symtab: Symtab, sroot1: String, sroot2: String) {
         symtab.get(ssym) match {
           case Some(sinfo) =>
             if (ssym.isExistential) {
+              // FIXME: https://github.com/twitter/rsc/issues/94
               TypeName(gensym.wildcardExistential())
             } else {
               sinfo.kind match {
@@ -609,6 +614,8 @@ class Pickle(abi: Abi, symtab: Symtab, sroot1: String, sroot2: String) {
       symtab.contains(ssym) && symtab(ssym).name == "<refinement>"
     }
     def isExistential: Boolean = {
+      // FIXME: https://github.com/twitter/rsc/issues/94
+      // FIXME: https://github.com/twitter/rsc/issues/95
       ssym.isLocal
     }
     def isValueClass: Boolean = {
@@ -915,6 +922,7 @@ class Pickle(abi: Abi, symtab: Symtab, sroot1: String, sroot2: String) {
     }
     def scaseAccessor(sgetterSym: String): s.SymbolInformation = {
       val saccessorName = {
+        // FIXME: https://github.com/twitter/rsc/issues/99
         if (abi == Scalac211) gensym.caseAccessor(sgetterSym.desc.name)
         else crash(abi)
       }

--- a/mjar/scalasig/src/main/scala/scala/meta/internal/scalasig/ScalasigHighlevel.scala
+++ b/mjar/scalasig/src/main/scala/scala/meta/internal/scalasig/ScalasigHighlevel.scala
@@ -194,6 +194,7 @@ class ScalasigHighlevel(lscalasig: l.Scalasig) {
             val hvalues = lvalues.map(_.resolve[h.JavaAnnotValue])
             h.AnnotArgArray(hvalues)
           case l.Tree(lpayload) =>
+            // FIXME: https://github.com/twitter/rsc/issues/93
             val hpayload = lpayload
             h.Tree(hpayload)
           case _: l.Children =>

--- a/mjar/scalasig/src/main/scala/scala/meta/internal/scalasig/ScalasigLowlevel.scala
+++ b/mjar/scalasig/src/main/scala/scala/meta/internal/scalasig/ScalasigLowlevel.scala
@@ -7,6 +7,7 @@ import scala.meta.scalasig.{lowlevel => l}
 
 object ScalasigLowlevel {
   def apply(hscalasig: h.Scalasig): l.Scalasig = {
+    // WONTFIX: https://github.com/twitter/rsc/issues/119
     ???
   }
 }

--- a/mjar/scalasig/src/main/scala/scala/meta/scalasig/highlevel/Entities.scala
+++ b/mjar/scalasig/src/main/scala/scala/meta/scalasig/highlevel/Entities.scala
@@ -74,3 +74,4 @@ sealed trait ScalaAnnotValue extends Entity
 sealed trait JavaAnnotValue extends Entity
 case class AnnotArgArray(values: List[JavaAnnotValue]) extends JavaAnnotValue
 case class Tree(payload: List[Byte]) extends ScalaAnnotValue
+// FIXME: https://github.com/twitter/rsc/issues/93

--- a/mjar/scalasig/src/main/scala/scala/meta/scalasig/lowlevel/Entities.scala
+++ b/mjar/scalasig/src/main/scala/scala/meta/scalasig/lowlevel/Entities.scala
@@ -67,5 +67,6 @@ sealed trait ScalaAnnotValue extends Entry
 sealed trait JavaAnnotValue extends Entry
 case class AnnotArgArray(values: List[Ref]) extends Entry with JavaAnnotValue
 
+// FIXME: https://github.com/twitter/rsc/issues/93
 case class Tree(payload: List[Byte]) extends Entry with ScalaAnnotValue
 case class Modifiers(payload: List[Byte]) extends Entry

--- a/rsc/src/main/scala/rsc/outline/Atoms.scala
+++ b/rsc/src/main/scala/rsc/outline/Atoms.scala
@@ -5,6 +5,8 @@ package rsc.outline
 import rsc.pretty._
 import rsc.syntax._
 
+// FIXME: https://github.com/twitter/rsc/issues/104
+
 sealed trait Atom extends Pretty with Product {
   def printStr(p: Printer): Unit = PrettyAtom.str(p, this)
   def printRepl(p: Printer): Unit = PrettyAtom.repl(p, this)

--- a/rsc/src/main/scala/rsc/outline/Env.scala
+++ b/rsc/src/main/scala/rsc/outline/Env.scala
@@ -118,6 +118,7 @@ sealed class Env protected (val _scopes: List[Scope]) extends Pretty {
   }
 
   def resolveSuper(mix: Option[Name]): Resolution = {
+    // FIXME: https://github.com/twitter/rsc/issues/96
     ???
   }
 

--- a/rsc/src/main/scala/rsc/outline/Outliner.scala
+++ b/rsc/src/main/scala/rsc/outline/Outliner.scala
@@ -8,6 +8,7 @@ import rsc.settings._
 import rsc.syntax._
 import rsc.util._
 
+// FIXME: https://github.com/twitter/rsc/issues/104
 final class Outliner private (
     settings: Settings,
     reporter: Reporter,
@@ -105,6 +106,7 @@ final class Outliner private (
         }
       }
     }
+    // FIXME: https://github.com/twitter/rsc/issues/98
     def synthesizeParents(env: Env, tree: DefnTemplate): Unit = {
       scope.tree match {
         case tree if tree.hasCase =>
@@ -249,10 +251,12 @@ final class Outliner private (
       case TptByName(tpt) =>
         apply(env, sketch, tpt)
       case TptExistential(tpt, stats) =>
+        // FIXME: https://github.com/twitter/rsc/issues/94
         ()
       case tpt: TptPath =>
         apply(env, sketch, tpt: Path)
       case TptRefine(tpt, stats) =>
+        // FIXME: https://github.com/twitter/rsc/issues/95
         ()
       case TptRepeat(tpt) =>
         apply(env, sketch, tpt)
@@ -260,6 +264,7 @@ final class Outliner private (
         ubound.foreach(apply(env, sketch, _))
         lbound.foreach(apply(env, sketch, _))
       case TptWildcardExistential(_, tpt) =>
+        // FIXME: https://github.com/twitter/rsc/issues/94
         apply(env, sketch, tpt)
       case TptWith(tpts) =>
         tpts.foreach(apply(env, sketch, _))
@@ -324,6 +329,7 @@ final class Outliner private (
                   resolution
               }
             case TptProject(qual, id) =>
+              // FIXME: https://github.com/twitter/rsc/issues/91
               reporter.append(IllegalOutline(qual))
               ErrorResolution
             case TptSelect(qual, id) =>
@@ -376,6 +382,7 @@ final class Outliner private (
           case tpt: TptPath =>
             tpt.id.sym match {
               case NoSymbol =>
+                // FIXME: https://github.com/twitter/rsc/issues/104
                 BlockedResolution(null)
               case sym =>
                 FoundResolution(sym)

--- a/rsc/src/main/scala/rsc/outline/Scheduler.scala
+++ b/rsc/src/main/scala/rsc/outline/Scheduler.scala
@@ -10,6 +10,7 @@ import rsc.settings._
 import rsc.syntax._
 import rsc.util._
 
+// FIXME: https://github.com/twitter/rsc/issues/98
 final class Scheduler private (
     settings: Settings,
     reporter: Reporter,

--- a/rsc/src/main/scala/rsc/outline/Synthesizer.scala
+++ b/rsc/src/main/scala/rsc/outline/Synthesizer.scala
@@ -9,6 +9,7 @@ import rsc.settings._
 import rsc.syntax._
 import rsc.util._
 
+// FIXME: https://github.com/twitter/rsc/issues/98
 final class Synthesizer private (
     settings: Settings,
     reporter: Reporter,

--- a/rsc/src/main/scala/rsc/outline/Work.scala
+++ b/rsc/src/main/scala/rsc/outline/Work.scala
@@ -10,6 +10,7 @@ abstract class Work extends Pretty {
   var status: Status = PendingStatus
 
   def block(dep: Work): Unit = {
+    // FIXME: https://github.com/twitter/rsc/issues/104
     if (dep == null) return
     status match {
       case PendingStatus =>

--- a/rsc/src/main/scala/rsc/parse/Terms.scala
+++ b/rsc/src/main/scala/rsc/parse/Terms.scala
@@ -44,7 +44,7 @@ trait Terms {
       }
       accept(ARROW)
       val rhs = term(inBlock)
-      crash("implicit blocks")
+      crash("https://github.com/twitter/rsc/issues/102")
     } else {
       wrapEscapingTermWildcards {
         val start = in.offset

--- a/rsc/src/main/scala/rsc/pretty/PrettyResolution.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyResolution.scala
@@ -9,6 +9,7 @@ object PrettyResolution {
     x match {
       case BlockedResolution(work) =>
         p.str("b:")
+        // FIXME: https://github.com/twitter/rsc/issues/104
         if (work != null) PrettyWork.abbr(p, work)
         else p.str("null")
       case MissingResolution =>

--- a/rsc/src/main/scala/rsc/semanticdb/Semanticdb.scala
+++ b/rsc/src/main/scala/rsc/semanticdb/Semanticdb.scala
@@ -230,6 +230,7 @@ final class Semanticdb private (
     }
 
     def annotations: List[s.Annotation] = {
+      // FIXME: https://github.com/twitter/rsc/issues/93
       Nil
     }
 
@@ -330,6 +331,7 @@ final class Semanticdb private (
 
   implicit class ModSemanticdbOps(mods: Mods) {
     def annotations: List[s.Annotation] = {
+      // FIXME: https://github.com/twitter/rsc/issues/93
       mods.annots.map(annot => s.Annotation(tpe = s.NoType))
     }
   }
@@ -378,27 +380,36 @@ final class Semanticdb private (
                 s.ExistentialType(typeRef(targs1), scope)
               }
             case other =>
+              // FIXME: https://github.com/scalameta/scalameta/issues/1565
               crash(other)
           }
         case TptByName(tpt) =>
           s.ByNameType(tpt.tpe)
         case TptExistential(tpt, stats) =>
+          // FIXME: https://github.com/twitter/rsc/issues/94
           s.NoType
         case tpt: TptId =>
+          // FIXME: https://github.com/twitter/rsc/issues/90
           s.TypeRef(s.NoType, tpt.sym, Nil)
         case tpt: TptProject =>
+          // FIXME: https://github.com/twitter/rsc/issues/91
           s.NoType
         case TptRefine(tpt, stats) =>
+          // FIXME: https://github.com/twitter/rsc/issues/95
           s.NoType
         case TptRepeat(tpt) =>
           s.RepeatedType(tpt.tpe)
         case tpt: TptSelect =>
+          // FIXME: https://github.com/twitter/rsc/issues/90
           s.TypeRef(s.NoType, tpt.id.sym, Nil)
         case TptSingleton(id: TermId) =>
+          // FIXME: https://github.com/twitter/rsc/issues/90
           s.SingleType(s.NoType, id.sym)
         case TptSingleton(TermSelect(_, id)) =>
+          // FIXME: https://github.com/twitter/rsc/issues/90
           s.SingleType(s.NoType, id.sym)
         case TptSingleton(_: TermSuper) =>
+          // FIXME: https://github.com/twitter/rsc/issues/96
           s.NoType
         case TptSingleton(TermThis(id)) =>
           s.ThisType(id.sym)


### PR DESCRIPTION
This commit links various todos in our code to tickets in the issue tracker of the project. FIXME/WONTFIX comments have been working very well in Scalameta, so we'll be adopting this convention in Rsc as well.