### PR TITLE
Upgrade to Scalameta 4.0.0-M6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val V = new {
   val asm = "6.0"
   val scala = computeScalaVersionFromTravisYml("2.11")
-  val scalameta = "4.0.0-M4-190-a8c817e9-SNAPSHOT"
+  val scalameta = "4.0.0-M6"
   val scalapb = _root_.scalapb.compiler.Version.scalapbVersion
   val scalatest = "3.0.5"
 }


### PR DESCRIPTION
4.0.0-M5 was dead on arrival, so we're skipping it.