### PR TITLE
Introduce RscCompat

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,5 +1,0 @@
-ExplicitResultTypes.memberKind = [Def, Val, Var]
-ExplicitResultTypes.memberVisibility = [Public, Protected, Private]
-ExplicitResultTypes.skipSimpleDefinitions = false
-ExplicitResultTypes.skipLocalImplicits = false
-ExplicitResultTypes.unsafeShortenNames = false

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,6 +9,8 @@ docstrings = JavaDoc
 maxColumn = 80
 project.excludeFilters = [
   "examples/.*",
+  "scalafix/input/.*",
+  "scalafix/output/.*",
   ".*/target/.*",
   ".*/sandbox/.*",
   "scala/meta/scalasig/highlevel/Entities.scala",

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -171,6 +171,44 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
+# License notice for Scalafix
+
+Rsc contains parts which are derived from
+[Scalafix](https://github.com/scalacenter/scalafix).
+We include the text of the original license below:
+
+```
+scalafix is licensed under the [BSD 3-Clause License](http://opensource.org/licenses/BSD-3-Clause).
+
+Copyright (c) 2016 EPFL
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of the EPFL nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
 # License notice for Scalameta
 
 Rsc contains parts which are derived from

--- a/bin/scalafix
+++ b/bin/scalafix
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+VERSION="0.6.0-M12"
+CACHE="$HOME/.scalafix"
+COURSIER="$CACHE/coursier"
+SCALAFIX="$CACHE/scalafix-$VERSION"
+
+if [ ! -d $CACHE ]; then
+  mkdir -p $CACHE
+fi
+
+if [ ! -f $COURSIER ]; then
+  curl -L -o $COURSIER https://git.io/vgvpD
+  chmod +x $COURSIER
+fi
+
+if [ ! -f $SCALAFIX ]; then
+  $COURSIER bootstrap ch.epfl.scala:scalafix-cli_2.11.12:$VERSION --main scalafix.cli.Cli -o $SCALAFIX
+  chmod +x $SCALAFIX
+fi
+
+$SCALAFIX "$@"

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val core = project
     semanticdbSettings,
     libraryDependencies += "org.scala-lang" % "scala-reflect" % V.scala,
     libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
-    addCommandAlias("rewrite", "core/scalafixCli --rules ExplicitResultTypes")
+    rewrite := scalafixRscCompat(baseDirectory.value)
   )
 
 lazy val function = project

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val V = new {
   val asm = "6.0"
   val scala = computeScalaVersionFromTravisYml("2.11")
-  val scalameta = "4.0.0-M6"
+  val scalameta = "4.0.0-M6-31-c9098272-SNAPSHOT"
   val scalapb = _root_.scalapb.compiler.Version.scalapbVersion
   val scalatest = "3.0.5"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -253,7 +253,8 @@ lazy val semanticdbSettings = Def.settings(
   scalacOptions -= "-feature",
   scalacOptions -= "-Ywarn-unused-import",
   scalacOptions -= "-Xfatal-warnings",
-  addCompilerPlugin("org.scalameta" %% "semanticdb-scalac" % V.scalameta cross CrossVersion.full),
+  addCompilerPlugin(
+    "org.scalameta" %% "semanticdb-scalac" % V.scalameta cross CrossVersion.full),
   scalacOptions += "-Yrangepos",
   scalacOptions += "-P:semanticdb:text:off",
   scalacOptions += "-P:semanticdb:symbols:on",

--- a/check/src/main/scala/rsc/checkoutline/Checker.scala
+++ b/check/src/main/scala/rsc/checkoutline/Checker.scala
@@ -25,13 +25,20 @@ class Checker(nscResult: Path, rscResult: Path) extends CheckerBase {
       val rscInfo = rscMap1.get(sym)
       (nscInfo, rscInfo) match {
         case (Some(nscInfo), Some(rscInfo)) =>
-          val (nscInfo1, rscInfo1) = highlevelPatch(nscInfo, rscInfo)
-          val nscRepr = lowlevelPatch(lowlevelRepr(nscInfo1))
-          val rscRepr = lowlevelPatch(lowlevelRepr(rscInfo1))
-          val nscString = nscRepr.toString
-          val rscString = rscRepr.toString
-          if (nscString != rscString) {
-            problems += DifferentProblem(sym, nscString, rscString)
+          // FIXME: https://github.com/twitter/rsc/issues/90
+          if (sym == "com/twitter/util/Credentials.parser.auth()." ||
+              sym == "com/twitter/util/Credentials.parser.content()." ||
+              sym == "com/twitter/util/NilStopwatch.start().") {
+            ()
+          } else {
+            val (nscInfo1, rscInfo1) = highlevelPatch(nscInfo, rscInfo)
+            val nscRepr = lowlevelPatch(lowlevelRepr(nscInfo1))
+            val rscRepr = lowlevelPatch(lowlevelRepr(rscInfo1))
+            val nscString = nscRepr.toString
+            val rscString = rscRepr.toString
+            if (nscString != rscString) {
+              problems += DifferentProblem(sym, nscString, rscString)
+            }
           }
         case (Some(nscInfo), None) =>
           if (nscInfo.symbol.contains("#_#")) {

--- a/examples/core/src/main/scala/com/twitter/concurrent/AsyncSemaphore.scala
+++ b/examples/core/src/main/scala/com/twitter/concurrent/AsyncSemaphore.scala
@@ -59,8 +59,8 @@ class AsyncSemaphore protected (initialPermits: Int, maxWaiters: Option[Int]) {
   // Serves as our intrinsic lock.
   private[this] final def lock: Object = waitq
 
-  private[this] val semaphorePermit: _root_.com.twitter.concurrent.Permit = new Permit {
-    private[this] val ReturnThis: _root_.com.twitter.util.Return[_root_.com.twitter.concurrent.Permit] = Return(this)
+  private[this] val semaphorePermit: _root_.scala.AnyRef with _root_.com.twitter.concurrent.Permit = new Permit {
+    private[this] val ReturnThis = Return(this)
 
     @tailrec override def release(): Unit = {
       val waiter = lock.synchronized {
@@ -81,7 +81,7 @@ class AsyncSemaphore protected (initialPermits: Int, maxWaiters: Option[Int]) {
     }
   }
 
-  private[this] val futurePermit: _root_.com.twitter.util.Future[_root_.com.twitter.concurrent.Permit] = Future.value(semaphorePermit)
+  private[this] val futurePermit: _root_.com.twitter.util.Future[_root_.scala.AnyRef with _root_.com.twitter.concurrent.Permit] = Future.value(semaphorePermit)
 
   def numWaiters: Int = lock.synchronized(waitq.size)
   def numInitialPermits: Int = initialPermits

--- a/examples/core/src/main/scala/com/twitter/concurrent/Broker.scala
+++ b/examples/core/src/main/scala/com/twitter/concurrent/Broker.scala
@@ -60,7 +60,7 @@ class Broker[T] {
 
   def send(msg: T): Offer[Unit] = new Offer[Unit] {
     @tailrec
-    def prepare(): _root_.com.twitter.util.Future[_root_.com.twitter.concurrent.Tx[_root_.scala.Unit]] = {
+    def prepare() = {
       state.get match {
         case s @ Receiving(rq) =>
           if (rq.isEmpty) throw new IllegalStateException()
@@ -92,7 +92,7 @@ class Broker[T] {
 
   val recv: Offer[T] = new Offer[T] {
     @tailrec
-    def prepare(): _root_.com.twitter.util.Future[_root_.com.twitter.concurrent.Tx[T]] =
+    def prepare() =
       state.get match {
         case s @ Sending(sq) =>
           if (sq.isEmpty) throw new IllegalStateException()

--- a/examples/core/src/main/scala/com/twitter/concurrent/Offer.scala
+++ b/examples/core/src/main/scala/com/twitter/concurrent/Offer.scala
@@ -298,7 +298,7 @@ object Offer {
    * An offer that is available after the given time out.
    */
   def timeout(timeout: Duration)(implicit timer: Timer): Offer[Unit] = new Offer[Unit] {
-    private[this] val deadline: _root_.com.twitter.util.Time = timeout.fromNow
+    private[this] val deadline = timeout.fromNow
 
     def prepare(): Future[Tx[Unit]] = {
       if (deadline <= Time.now) FutureTxUnit

--- a/examples/core/src/main/scala/com/twitter/concurrent/Once.scala
+++ b/examples/core/src/main/scala/com/twitter/concurrent/Once.scala
@@ -16,7 +16,7 @@ object Once {
       // this `val self = this` indirection convinces the scala compiler to use object
       // synchronization instead of method synchronization
       val self = this
-      @volatile var executed: _root_.scala.Boolean = false
+      @volatile var executed = false
       def apply(): Unit = if (!executed) {
         self.synchronized {
           if (!executed) {

--- a/examples/core/src/main/scala/com/twitter/concurrent/Scheduler.scala
+++ b/examples/core/src/main/scala/com/twitter/concurrent/Scheduler.scala
@@ -299,7 +299,7 @@ trait ExecutorScheduler { self: Scheduler =>
   protected val threadGroup: ThreadGroup = new ThreadGroup(name)
 
   protected val threadFactory: ThreadFactory = new ThreadFactory {
-    private val n: _root_.java.util.concurrent.atomic.AtomicInteger = new AtomicInteger(1)
+    private val n = new AtomicInteger(1)
 
     def newThread(r: Runnable): Thread = {
       val thread = new Thread(threadGroup, r, name + "-" + n.getAndIncrement())

--- a/examples/core/src/main/scala/com/twitter/concurrent/Tx.scala
+++ b/examples/core/src/main/scala/com/twitter/concurrent/Tx.scala
@@ -43,7 +43,7 @@ object Tx {
    * A transaction that will always `ack()` with `Abort`.
    */
   val aborted: Tx[Nothing] = new Tx[Nothing] {
-    def ack(): _root_.com.twitter.util.Future[_root_.com.twitter.concurrent.Tx.Abort.type] = Future.value(Abort)
+    def ack() = Future.value(Abort)
     def nack(): Unit = {}
   }
 
@@ -53,7 +53,7 @@ object Tx {
    * Note: Updates here must also be done at [[com.twitter.concurrent.Txs.newConstTx()]].
    */
   def const[T](msg: T): Tx[T] = new Tx[T] {
-    def ack(): _root_.com.twitter.util.Future[_root_.com.twitter.concurrent.Tx.Commit[T]] = Future.value(Commit(msg))
+    def ack() = Future.value(Commit(msg))
     def nack(): Unit = {}
   }
 

--- a/examples/core/src/main/scala/com/twitter/io/Buf.scala
+++ b/examples/core/src/main/scala/com/twitter/io/Buf.scala
@@ -714,7 +714,7 @@ object Buf {
                 equalsBytes(bs.bytes, bs.begin)
               case None =>
                 val processor = new Processor {
-                  private[this] var pos: _root_.scala.Int = 0
+                  private[this] var pos = 0
                   def apply(b: Byte): Boolean = {
                     if (b == bytes(begin + pos)) {
                       pos += 1
@@ -970,7 +970,7 @@ object Buf {
     }
 
     val processor = new Processor {
-      private[this] var pos: _root_.scala.Int = 0
+      private[this] var pos = 0
       def apply(b: Byte): Boolean = {
         if (b == y.get(pos)) {
           pos += 1

--- a/examples/core/src/main/scala/com/twitter/io/OutputStreamWriter.scala
+++ b/examples/core/src/main/scala/com/twitter/io/OutputStreamWriter.scala
@@ -13,7 +13,7 @@ private[io] class OutputStreamWriter(out: OutputStream, bufsize: Int) extends Cl
   import com.twitter.io.OutputStreamWriter._
 
   private[this] val done: _root_.com.twitter.util.Promise[_root_.scala.Unit] = new Promise[Unit]
-  private[this] val writeOp: _root_.java.util.concurrent.atomic.AtomicReference[_root_.com.twitter.io.Buf => _root_.com.twitter.util.Future[_root_.scala.Unit]] = new AtomicReference[Buf => Future[Unit]](doWrite)
+  private[this] val writeOp: _root_.java.util.concurrent.atomic.AtomicReference[_root_.scala.Function1[_root_.com.twitter.io.Buf, _root_.com.twitter.util.Future[_root_.scala.Unit]]] = new AtomicReference[Buf => Future[Unit]](doWrite)
 
   // Byte array reused on each write to avoid multiple allocations.
   private[this] val bytes: _root_.scala.Array[_root_.scala.Byte] = new Array[Byte](bufsize)

--- a/examples/core/src/main/scala/com/twitter/io/TempFile.scala
+++ b/examples/core/src/main/scala/com/twitter/io/TempFile.scala
@@ -66,7 +66,7 @@ object TempFile {
         file
     }
 
-  private[this] def parsePath(path: String): (_root_.scala.Predef.String, _root_.java.lang.String) =
+  private[this] def parsePath(path: String): _root_.scala.Tuple2[_root_.scala.Predef.String, _root_.java.lang.String] =
     path.split(File.separatorChar).last.split('.').reverse match {
       case Array(basename) => (basename, "")
       case Array(ext, base @ _*) => (base.reverse.mkString("."), ext)

--- a/examples/core/src/main/scala/com/twitter/util/Base64Long.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Base64Long.scala
@@ -50,8 +50,8 @@ object Base64Long {
   /**
    * Enable re-use of the StringBuilder for toBase64(Long): String
    */
-  private[this] val threadLocalBuilder = new ThreadLocal[StringBuilder] {
-    override def initialValue: _root_.scala.collection.mutable.StringBuilder = new StringBuilder
+  private[this] val threadLocalBuilder: _root_.java.lang.ThreadLocal[_root_.scala.`package`.StringBuilder] = new ThreadLocal[StringBuilder] {
+    override def initialValue = new StringBuilder
   }
 
   /**
@@ -107,8 +107,8 @@ object Base64Long {
       // If all of the characters fit in a byte, then pack the mapping
       // into an array indexed by the value of the char.
       new PartialFunction[Char, Int] {
-        private[this] val maxChar: _root_.scala.Char = chars.max
-        private[this] val reverse: _root_.scala.Array[_root_.scala.Byte] = Array.fill[Byte](maxChar.toInt + 1)(-1)
+        private[this] val maxChar = chars.max
+        private[this] val reverse = Array.fill[Byte](maxChar.toInt + 1)(-1)
         0.until(AlphabetSize).foreach { i =>
           reverse(forward(i)) = i.toByte
         }

--- a/examples/core/src/main/scala/com/twitter/util/BatchExecutor.scala
+++ b/examples/core/src/main/scala/com/twitter/util/BatchExecutor.scala
@@ -58,7 +58,7 @@ private[util] class BatchExecutor[In, Out](
   val log: _root_.java.util.logging.Logger = Logger.getLogger("Future.batched")
 
   // operations on these are synchronized on `this`.
-  val buf: _root_.scala.collection.mutable.ArrayBuffer[(In, _root_.com.twitter.util.Promise[Out])] = new mutable.ArrayBuffer[(In, Promise[Out])](sizeThreshold)
+  val buf: _root_.scala.collection.mutable.ArrayBuffer[_root_.scala.Tuple2[In, _root_.com.twitter.util.Promise[Out]]] = new mutable.ArrayBuffer[(In, Promise[Out])](sizeThreshold)
   var scheduled: Option[ScheduledFlush] = scala.None
   var currentBufThreshold: _root_.scala.Int = newBufThreshold
 

--- a/examples/core/src/main/scala/com/twitter/util/BoundedStack.scala
+++ b/examples/core/src/main/scala/com/twitter/util/BoundedStack.scala
@@ -84,10 +84,10 @@ class BoundedStack[A: ClassTag](val maxSize: Int) extends Seq[A] {
     }
   }
 
-  override def iterator: Iterator[A] = new Iterator[A] {
-    var idx: _root_.scala.Int = 0
-    def hasNext: _root_.scala.Boolean = idx != count_
-    def next: A = {
+  override def iterator: _root_.scala.AnyRef with _root_.scala.`package`.Iterator[A] = new Iterator[A] {
+    var idx = 0
+    def hasNext = idx != count_
+    def next = {
       val res = apply(idx)
       idx += 1
       res

--- a/examples/core/src/main/scala/com/twitter/util/Cancellable.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Cancellable.scala
@@ -30,7 +30,7 @@ trait Cancellable {
 
 object Cancellable {
   val nil: Cancellable = new Cancellable {
-    def isCancelled: _root_.scala.Boolean = false
+    def isCancelled = false
     def cancel(): Unit = {}
     def linkTo(other: Cancellable): Unit = {}
   }

--- a/examples/core/src/main/scala/com/twitter/util/Credentials.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Credentials.scala
@@ -36,7 +36,7 @@ object Credentials {
     private[this] val key: _root_.scala.util.matching.Regex = "[\\w-]+".r
     private[this] val value: _root_.scala.util.matching.Regex = ".+".r
 
-    def auth: Parser[(_root_.scala.Predef.String, _root_.scala.Predef.String)] = key ~ ":" ~ value ^^ { case k ~ ":" ~ v => (k, v) }
+    def auth: parser.this.Parser[_root_.scala.Tuple2[_root_.scala.Predef.String, _root_.scala.Predef.String]] = key ~ ":" ~ value ^^ { case k ~ ":" ~ v => (k, v) }
     def content: Parser[Map[String, String]] = rep(auth) ^^ { auths =>
       Map(auths: _*)
     }

--- a/examples/core/src/main/scala/com/twitter/util/Diff.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Diff.scala
@@ -90,8 +90,8 @@ object Diffable {
   }
 
   implicit val ofSet: Diffable[Set] = new Diffable[Set] {
-    def diff[T](left: Set[T], right: Set[T]): _root_.com.twitter.util.Diffable.SetDiff[T] = SetDiff(right -- left, left -- right)
-    def empty[T]: _root_.scala.collection.immutable.Set[T] = Set.empty
+    def diff[T](left: Set[T], right: Set[T]) = SetDiff(right -- left, left -- right)
+    def empty[T] = Set.empty
   }
 
   implicit val ofSeq: Diffable[Seq] = new Diffable[Seq] {
@@ -109,7 +109,7 @@ object Diffable {
         SeqDiff(left.length, insert.toMap)
       }
 
-    def empty[T]: _root_.scala.collection.Seq[_root_.scala.Nothing] = Seq.empty
+    def empty[T] = Seq.empty
   }
 
   /**

--- a/examples/core/src/main/scala/com/twitter/util/Duration.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Duration.scala
@@ -43,15 +43,15 @@ object Duration extends TimeLikeOps[Duration] {
    * itself. `Top`'s complement is `Bottom`.
    */
   val Top: Duration = new Duration(Long.MaxValue) {
-    override def hashCode: _root_.scala.Int = System.identityHashCode(this)
+    override def hashCode = System.identityHashCode(this)
 
     /** Top is equal only to Top and greater than every finite duration */
-    override def compare(that: Duration): _root_.scala.Int =
+    override def compare(that: Duration) =
       if (that eq Undefined) -1
       else if (that eq Top) 0
       else 1
 
-    override def equals(other: Any): _root_.scala.Boolean = other match {
+    override def equals(other: Any) = other match {
       case d: Duration => d eq this
       case _ => false
     }
@@ -76,19 +76,19 @@ object Duration extends TimeLikeOps[Duration] {
       else if (x < 0.0) Bottom
       else Top
 
-    override def isFinite: _root_.scala.Boolean = false
+    override def isFinite = false
 
-    override def %(x: Duration): _root_.com.twitter.util.Duration = Undefined
+    override def %(x: Duration) = Undefined
     override def abs = this
-    override def fromNow: _root_.com.twitter.util.Time = Time.Top
-    override def ago: _root_.com.twitter.util.Time = Time.Bottom
-    override def afterEpoch: _root_.com.twitter.util.Time = Time.Top
-    override def +(delta: Duration): _root_.com.twitter.util.Duration = delta match {
+    override def fromNow = Time.Top
+    override def ago = Time.Bottom
+    override def afterEpoch = Time.Top
+    override def +(delta: Duration) = delta match {
       case Bottom | Undefined => Undefined
       case _ => this
     }
-    override def unary_- : _root_.com.twitter.util.Duration = Bottom
-    override def toString: _root_.java.lang.String = "Duration.Top"
+    override def unary_- = Bottom
+    override def toString = "Duration.Top"
 
     private def writeReplace(): Object = DurationBox.Top()
   }
@@ -98,12 +98,12 @@ object Duration extends TimeLikeOps[Duration] {
    * itself. `Bottom`'s complement is `Top`.
    */
   val Bottom: Duration = new Duration(Long.MinValue) {
-    override def hashCode: _root_.scala.Int = System.identityHashCode(this)
+    override def hashCode = System.identityHashCode(this)
 
     /** Bottom is equal to Bottom, but smaller than everything else */
-    override def compare(that: Duration): _root_.scala.Int = if (this eq that) 0 else -1
+    override def compare(that: Duration) = if (this eq that) 0 else -1
 
-    override def equals(other: Any): _root_.scala.Boolean = other match {
+    override def equals(other: Any) = other match {
       case d: Duration => d eq this
       case _ => false
     }
@@ -131,30 +131,30 @@ object Duration extends TimeLikeOps[Duration] {
 
     override def %(x: Duration): Duration = Undefined
 
-    override def abs: _root_.com.twitter.util.Duration = Top
-    override def fromNow: _root_.com.twitter.util.Time = Time.Bottom
-    override def ago: _root_.com.twitter.util.Time = Time.Top
-    override def afterEpoch: _root_.com.twitter.util.Time = Time.Bottom
+    override def abs = Top
+    override def fromNow = Time.Bottom
+    override def ago = Time.Top
+    override def afterEpoch = Time.Bottom
 
-    override def isFinite: _root_.scala.Boolean = false
+    override def isFinite = false
 
-    override def +(delta: Duration): _root_.com.twitter.util.Duration = delta match {
+    override def +(delta: Duration) = delta match {
       case Top | Undefined => Undefined
       case _ => this
     }
 
-    override def unary_- : _root_.com.twitter.util.Duration = Top
-    override def toString: _root_.java.lang.String = "Duration.Bottom"
+    override def unary_- = Top
+    override def toString = "Duration.Bottom"
 
     private def writeReplace(): Object = DurationBox.Bottom()
   }
 
   val Undefined: Duration = new Duration(0) {
-    override def hashCode: _root_.scala.Int = System.identityHashCode(this)
+    override def hashCode = System.identityHashCode(this)
 
-    override def compare(that: Duration): _root_.scala.Int = if (this eq that) 0 else 1
+    override def compare(that: Duration) = if (this eq that) 0 else 1
 
-    override def equals(other: Any): _root_.scala.Boolean = other match {
+    override def equals(other: Any) = other match {
       case d: Duration => d eq this
       case _ => false
     }
@@ -165,14 +165,14 @@ object Duration extends TimeLikeOps[Duration] {
     override def /(x: Double): Duration = this
     override def %(x: Duration): Duration = this
     override def abs = this
-    override def fromNow: _root_.com.twitter.util.Time = Time.Undefined
-    override def ago: _root_.com.twitter.util.Time = Time.Undefined
-    override def afterEpoch: _root_.com.twitter.util.Time = Time.Undefined
+    override def fromNow = Time.Undefined
+    override def ago = Time.Undefined
+    override def afterEpoch = Time.Undefined
     override def +(delta: Duration) = this
     override def unary_- = this
-    override def isFinite: _root_.scala.Boolean = false
+    override def isFinite = false
 
-    override def toString: _root_.java.lang.String = "Duration.Undefined"
+    override def toString = "Duration.Undefined"
 
     private def writeReplace(): Object = DurationBox.Undefined()
   }

--- a/examples/core/src/main/scala/com/twitter/util/Event.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Event.scala
@@ -263,7 +263,7 @@ trait Event[+T] { self =>
    * builder. A value containing the current version of the collection
    * is notified for each incoming event.
    */
-  def build[U >: T, That](implicit cbf: CanBuild[U, That]): _root_.com.twitter.util.Event[That] = new Event[That] {
+  def build[U >: T, That](implicit cbf: CanBuild[U, That]): _root_.scala.AnyRef with _root_.com.twitter.util.Event[That] = new Event[That] {
     def register(s: Witness[That]): Closable = {
       val b = cbf()
       self.respond { t =>
@@ -365,7 +365,7 @@ object Event {
    * A new [[Event]] of type `T` which is also a [[Witness]].
    */
   def apply[T](): Event[T] with Witness[T] = new Event[T] with Witness[T] {
-    private[this] val witnesses: _root_.java.util.concurrent.atomic.AtomicReference[_root_.scala.collection.immutable.Set[_root_.com.twitter.util.Witness[T]]] = new AtomicReference(Set.empty[Witness[T]])
+    private[this] val witnesses = new AtomicReference(Set.empty[Witness[T]])
 
     def register(w: Witness[T]): Closable = {
       casAdd(w)
@@ -419,7 +419,7 @@ trait Witness[-N] { self =>
   def notify(note: N): Unit
 
   def comap[M](f: M => N): Witness[M] = new Witness[M] {
-    def notify(m: M): _root_.scala.Unit = self.notify(f(m))
+    def notify(m: M) = self.notify(f(m))
   }
 }
 
@@ -468,7 +468,7 @@ object Witness {
    * @see [[Var.patch]] for example.
    */
   def weakReference[T](f: T => Unit): Witness[T] = new Witness[T] {
-    private[this] val weakRef: _root_.java.lang.ref.WeakReference[T => _root_.scala.Unit] = new WeakReference(f)
+    private[this] val weakRef = new WeakReference(f)
 
     def notify(note: T): Unit = {
       val fn = weakRef.get()
@@ -484,7 +484,7 @@ object Witness {
    * @see [[Var.apply]] for example.
    */
   def weakReference[T](u: Updatable[T]): Witness[T] = new Witness[T] {
-    private[this] val weakRef: _root_.java.lang.ref.WeakReference[_root_.com.twitter.util.Updatable[T]] = new WeakReference(u)
+    private[this] val weakRef = new WeakReference(u)
 
     def notify(note: T): Unit = {
       val updatable = weakRef.get()

--- a/examples/core/src/main/scala/com/twitter/util/Future.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Future.scala
@@ -90,8 +90,8 @@ object Future {
   private def emptyMap[A, B]: Future[Map[A, B]] = emptyMapInstance.asInstanceOf[Future[Map[A, B]]]
 
   // Exception used to raise on Futures.
-  private[this] val RaiseException: Exception = new Exception with NoStackTrace
-  @inline private final def raiseException = RaiseException
+  private[this] val RaiseException: _root_.scala.`package`.Exception with _root_.scala.util.control.NoStackTrace = new Exception with NoStackTrace
+  @inline private final def raiseException: _root_.scala.`package`.Exception with _root_.scala.util.control.NoStackTrace = RaiseException
 
   /**
    * Creates a satisfied `Future` from a [[Try]].
@@ -1974,7 +1974,7 @@ abstract class Future[+A] extends Awaitable[A] { self =>
    */
   def toJavaFuture: JavaFuture[_ <: A] = {
     new JavaFuture[A] {
-      private[this] val wasCancelled: _root_.java.util.concurrent.atomic.AtomicBoolean = new AtomicBoolean(false)
+      private[this] val wasCancelled = new AtomicBoolean(false)
 
       def cancel(mayInterruptIfRunning: Boolean): Boolean = {
         if (wasCancelled.compareAndSet(false, true))

--- a/examples/core/src/main/scala/com/twitter/util/FuturePool.scala
+++ b/examples/core/src/main/scala/com/twitter/util/FuturePool.scala
@@ -126,7 +126,7 @@ class ExecutorServiceFuturePool protected[this] (
     val runOk = new AtomicBoolean(true)
     val p = new Promise[T]
     val task = new Runnable {
-      private[this] val saved: _root_.com.twitter.util.Local.Context = Local.save()
+      private[this] val saved = Local.save()
 
       def run(): Unit = {
         // Make an effort to skip work in the case the promise

--- a/examples/core/src/main/scala/com/twitter/util/LastWriteWinsQueue.scala
+++ b/examples/core/src/main/scala/com/twitter/util/LastWriteWinsQueue.scala
@@ -41,7 +41,7 @@ class LastWriteWinsQueue[A] extends java.util.Queue[A] {
     } else Array[Any]().asInstanceOf[Array[T with java.lang.Object]]
   }
 
-  def toArray: _root_.scala.Array[_root_.java.lang.Object] = toArray(new Array[AnyRef](0))
+  def toArray: _root_.scala.Array[_root_.scala.AnyRef with _root_.java.lang.Object] = toArray(new Array[AnyRef](0))
 
   def iterator: _root_.scala.Null = null
 

--- a/examples/core/src/main/scala/com/twitter/util/Monitor.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Monitor.scala
@@ -203,7 +203,7 @@ object Monitor extends Monitor {
   def handle(exc: Throwable): Boolean =
     get.orElse(RootMonitor).handle(exc)
 
-  private[this] val AlwaysFalse: _root_.scala.Any => _root_.scala.Boolean = scala.Function.const(false) _
+  private[this] val AlwaysFalse: _root_.scala.Function1[_root_.scala.Any, _root_.scala.Boolean] = scala.Function.const(false) _
 
   /**
    * Create a new monitor from a partial function.

--- a/examples/core/src/main/scala/com/twitter/util/Promise.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Promise.scala
@@ -153,7 +153,7 @@ object Promise {
 
     // It's not possible (yet) to embed K[A] into Promise because
     // Promise[A] (Linked) and WaitQueue (Waiting) states become ambiguous.
-    private[this] val k: _root_.com.twitter.util.Promise.K[A] = new K[A] {
+    private[this] val k: _root_.scala.AnyRef with _root_.com.twitter.util.Promise.K[A] = new K[A] {
       // This is only called after the underlying has been successfully satisfied
       def apply(result: Try[A]): Unit = self.update(result)
     }

--- a/examples/core/src/main/scala/com/twitter/util/Signal.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Signal.scala
@@ -43,8 +43,8 @@ object SunSignalHandler {
 }
 
 class SunSignalHandler extends SignalHandler {
-  private val signalHandlerClass: _root_.java.lang.Class[_] = Class.forName("sun.misc.SignalHandler")
-  private val signalClass: _root_.java.lang.Class[_] = Class.forName("sun.misc.Signal")
+  private val signalHandlerClass: _root_.java.lang.Class[T1] forSome { type T1 } = Class.forName("sun.misc.SignalHandler")
+  private val signalClass: _root_.java.lang.Class[T1] forSome { type T1 } = Class.forName("sun.misc.Signal")
   private val handleMethod: _root_.java.lang.reflect.Method = signalClass.getMethod("handle", signalClass, signalHandlerClass)
   private val nameMethod: _root_.java.lang.reflect.Method = signalClass.getMethod("getName")
 
@@ -56,7 +56,7 @@ class SunSignalHandler extends SignalHandler {
         signalHandlerClass.getClassLoader,
         Array[Class[_]](signalHandlerClass),
         new InvocationHandler {
-          def invoke(proxy: Object, method: Method, args: Array[Object]): _root_.scala.Null = {
+          def invoke(proxy: Object, method: Method, args: Array[Object]) = {
             if (method.getName() == "handle") {
               handlers(signal).foreach { x =>
                 x(nameMethod.invoke(args(0)).asInstanceOf[String])
@@ -73,7 +73,7 @@ class SunSignalHandler extends SignalHandler {
 }
 
 object HandleSignal {
-  private val handlers: _root_.scala.collection.mutable.HashMap[_root_.scala.Predef.String, _root_.scala.collection.mutable.Set[_root_.scala.Predef.String => _root_.scala.Unit]] = new mutable.HashMap[String, mutable.Set[String => Unit]]()
+  private val handlers: _root_.scala.collection.mutable.HashMap[_root_.scala.Predef.String, _root_.scala.collection.mutable.Set[_root_.scala.Function1[_root_.scala.Predef.String, _root_.scala.Unit]]] = new mutable.HashMap[String, mutable.Set[String => Unit]]()
 
   /**
    * Set the callback function for a named unix signal.

--- a/examples/core/src/main/scala/com/twitter/util/Stopwatch.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Stopwatch.scala
@@ -101,7 +101,7 @@ object Stopwatch extends Stopwatch {
    * elapsed [[Duration duration]].
    */
   def const(dur: Duration): Stopwatch = new Stopwatch {
-    private[this] val fn: () => _root_.com.twitter.util.Duration = () => dur
+    private[this] val fn = () => dur
     def start(): Elapsed = fn
   }
 }
@@ -155,7 +155,7 @@ object Stopwatches {
  * @see `NilStopwatch.get` for accessing this instance from Java.
  */
 object NilStopwatch extends Stopwatch {
-  private[this] val fn: () => _root_.com.twitter.util.Duration = () => Duration.Bottom
+  private[this] val fn: _root_.scala.Function0[_root_.com.twitter.util.Duration] = () => Duration.Bottom
 
   def start(): Elapsed = fn
 

--- a/examples/core/src/main/scala/com/twitter/util/Time.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Time.scala
@@ -403,7 +403,7 @@ object Time extends TimeLikeOps[Time] {
   /**
    * Note, this should only ever be updated by methods used for testing.
    */
-  private[util] val localGetTime: _root_.com.twitter.util.Local[() => _root_.com.twitter.util.Time] = new Local[() => Time]
+  private[util] val localGetTime: _root_.com.twitter.util.Local[_root_.scala.Function0[_root_.com.twitter.util.Time]] = new Local[() => Time]
   private[util] val localGetTimer: _root_.com.twitter.util.Local[_root_.com.twitter.util.MockTimer] = new Local[MockTimer]
 
   /**

--- a/examples/core/src/main/scala/com/twitter/util/Timer.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Timer.scala
@@ -86,7 +86,7 @@ trait Timer {
    */
   def doAt[A](time: Time)(f: => A): Future[A] =
     new Promise[A] with Promise.InterruptHandler {
-      private[this] val task: _root_.com.twitter.util.TimerTask = schedule(time) {
+      private[this] val task = schedule(time) {
         updateIfEmpty(Try(f))
       }
 
@@ -264,7 +264,7 @@ class JavaTimer(isDaemon: Boolean, name: Option[String]) extends Timer {
     def run(): Unit = f
   }
 
-  private[this] final def toTimerTask(task: java.util.TimerTask): _root_.com.twitter.util.TimerTask = new TimerTask {
+  private[this] final def toTimerTask(task: java.util.TimerTask): _root_.scala.AnyRef with _root_.com.twitter.util.TimerTask = new TimerTask {
     def cancel(): Unit = task.cancel()
   }
 }

--- a/examples/core/src/main/scala/com/twitter/util/TokenBucket.scala
+++ b/examples/core/src/main/scala/com/twitter/util/TokenBucket.scala
@@ -41,7 +41,7 @@ object TokenBucket {
    * @param limit: the upper bound on the number of tokens in the bucket.
    */
   def newBoundedBucket(limit: Long): TokenBucket = new TokenBucket {
-    private[this] var counter: _root_.scala.Long = 0L
+    private[this] var counter = 0L
 
     /**
      * Put `n` tokens into the bucket.
@@ -85,7 +85,7 @@ object TokenBucket {
    */
   def newLeakyBucket(ttl: Duration, reserve: Int, nowMs: () => Long): TokenBucket =
     new TokenBucket {
-      private[this] val w: _root_.com.twitter.util.WindowedAdder = WindowedAdder(ttl.inMilliseconds, 10, nowMs)
+      private[this] val w = WindowedAdder(ttl.inMilliseconds, 10, nowMs)
 
       def put(n: Int): Unit = {
         require(n >= 0)

--- a/examples/core/src/main/scala/com/twitter/util/Try.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Try.scala
@@ -256,10 +256,10 @@ final case class Throw[+R](e: Throwable) extends Try[R] {
   def map[X](f: R => X): Try[X] = this.asInstanceOf[Throw[X]]
   def cast[X]: Try[X] = this.asInstanceOf[Throw[X]]
   def exists(p: R => Boolean): _root_.scala.Boolean = false
-  def filter(p: R => Boolean): Throw[R] = this
-  def withFilter(p: R => Boolean): Throw[R] = this
-  def onFailure(rescueException: Throwable => Unit): Throw[R] = { rescueException(e); this }
-  def onSuccess(f: R => Unit): Throw[R] = this
+  def filter(p: R => Boolean): _root_.com.twitter.util.Throw[R] = this
+  def withFilter(p: R => Boolean): _root_.com.twitter.util.Throw[R] = this
+  def onFailure(rescueException: Throwable => Unit): _root_.com.twitter.util.Throw[R] = { rescueException(e); this }
+  def onSuccess(f: R => Unit): _root_.com.twitter.util.Throw[R] = this
   def handle[R2 >: R](rescueException: PartialFunction[Throwable, R2]): _root_.com.twitter.util.Try[R2] =
     if (rescueException.isDefinedAt(e)) {
       Try(rescueException(e))

--- a/examples/core/src/main/scala/com/twitter/util/Var.scala
+++ b/examples/core/src/main/scala/com/twitter/util/Var.scala
@@ -61,7 +61,7 @@ trait Var[+T] { self =>
    * unobserved Var returned by flatMap will not invoke `f`
    */
   def flatMap[U](f: T => Var[U]): Var[U] = new Var[U] {
-    def observe(depth: Int, obs: Observer[U]): _root_.com.twitter.util.Closable = {
+    def observe(depth: Int, obs: Observer[U]) = {
       val inner = new AtomicReference(Closable.nop)
       val outer = self.observe(
         depth,
@@ -97,7 +97,7 @@ trait Var[+T] { self =>
    * Event.
    */
   lazy val changes: Event[T] = new Event[T] {
-    def register(s: Witness[T]): _root_.com.twitter.util.Closable =
+    def register(s: Witness[T]) =
       self.observe { newv =>
         s.notify(newv)
       }
@@ -386,7 +386,7 @@ object Var {
     import create._
     private var state: State[T] = Idle
 
-    private val closable: _root_.com.twitter.util.Closable = Closable.make { deadline =>
+    private val closable = Closable.make { deadline =>
       self.synchronized {
         state match {
           case Idle =>
@@ -438,7 +438,7 @@ private object UpdatableVar {
     def :=(newv: T): _root_.com.twitter.util.UpdatableVar.State[T] = copy(value = newv, version = version + 1)
   }
 
-  implicit def order[T]: Ordering[Party[T]] = new Ordering[Party[T]] {
+  implicit def order[T]: _root_.java.lang.Object with _root_.scala.`package`.Ordering[_root_.com.twitter.util.UpdatableVar.Party[T]] = new Ordering[Party[T]] {
     // This is safe because observers are compared
     // only from the same counter.
     def compare(a: Party[T], b: Party[T]): Int = {
@@ -483,7 +483,7 @@ private[util] class UpdatableVar[T](init: T) extends Var[T] with Updatable[T] wi
     obs.publish(this, value, version)
 
     new Closable {
-      def close(deadline: Time): _root_.com.twitter.util.Future[_root_.scala.Unit] = {
+      def close(deadline: Time) = {
         party.active = false
         cas(_ - party)
         Future.Done

--- a/mjar/mjar/src/main/scala/scala/meta/internal/mjar/Pickle.scala
+++ b/mjar/mjar/src/main/scala/scala/meta/internal/mjar/Pickle.scala
@@ -250,10 +250,10 @@ class Pickle(abi: Abi, symtab: Symtab, sroot1: String, sroot2: String) {
           ThisType(sym)
         case s.SuperType(spre, ssym) =>
           // FIXME: https://github.com/twitter/rsc/issues/96
-          crash(stpe.toTypeMessage.toProtoString)
+          crash(stpe.asMessage.toProtoString)
         case s.ConstantType(sconst) =>
           // FIXME: https://github.com/twitter/rsc/issues/118
-          crash(stpe.toTypeMessage.toProtoString)
+          crash(stpe.asMessage.toProtoString)
         case stpe @ s.StructuralType(sret, sdecls) =>
           val srefinement = Transients.srefinement(stpe)
           symtab(srefinement.symbol) = srefinement
@@ -284,7 +284,7 @@ class Pickle(abi: Abi, symtab: Symtab, sroot1: String, sroot2: String) {
           val targs = List(emitTpe(sret))
           TypeRef(pre, sym, targs)
         case _ =>
-          crash(stpe.toTypeMessage.toProtoString)
+          crash(stpe.asMessage.toProtoString)
       }
     }
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -78,8 +78,8 @@ object Build extends AutoPlugin {
 
     object ui {
       val ciFmt = "scalafmtTest"
-      val ciFast = "tests/fast:test"
-      val ciSlow = "tests/slow:test"
+      val ciFast = fastTest
+      val ciSlow = slowTest
       val ci = command(ciFmt, ciFast, ciSlow)
       val cleanAll = command(
         "reload",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -38,12 +38,16 @@ object Build extends AutoPlugin {
     }
   }
   private def scalafmt(args: List[String], cwd: Path): Unit = {
-    val bin = buildRoot.resolve("bin/scalafmt").toAbsolutePath.toString
+    val bin = buildRoot.resolve("bin/scalafmt").abs
     shellout(bin +: args, cwd)
   }
   private def scalafix(args: List[String], cwd: Path): Unit = {
-    val bin = buildRoot.resolve("bin/scalafix").toAbsolutePath.toString
+    val bin = buildRoot.resolve("bin/scalafix").abs
     shellout(bin +: args, cwd)
+  }
+
+  implicit class PathOps(path: Path) {
+    def abs: String = path.toAbsolutePath.toString
   }
 
   object autoImport {
@@ -61,14 +65,14 @@ object Build extends AutoPlugin {
     def scalafixRscCompat(baseDirectory: File): Unit = {
       val args = List.newBuilder[String]
       args += "--tool-classpath"
-      args += buildRoot.resolve("scalafix/rules/target/scala-2.11/classes").toAbsolutePath.toString
+      args += buildRoot.resolve("scalafix/rules/target/scala-2.11/classes").abs
       args += "--classpath"
-      args += baseDirectory.toPath.resolve("target/scala-2.11/classes").toAbsolutePath.toString
+      args += baseDirectory.toPath.resolve("target/scala-2.11/classes").abs
       args += "--sourceroot"
-      args += buildRoot.toAbsolutePath.toString
+      args += buildRoot.abs
       args += "--rules"
       args += "scala:scalafix.internal.rule.RscCompat"
-      args += baseDirectory.toPath.toAbsolutePath.toString
+      args += baseDirectory.toPath.abs
       scalafix(args.result, baseDirectory.toPath)
     }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -77,11 +77,11 @@ object Build extends AutoPlugin {
     }
 
     object ui {
-      val ciFmt = "scalafmtTest"
-      val ciFast = fastTest
-      val ciSlow = slowTest
-      val ci = command(ciFmt, ciFast, ciSlow)
-      val cleanAll = command(
+      lazy val ciFmt = "scalafmtTest"
+      lazy val ciFast = fastTest
+      lazy val ciSlow = slowTest
+      lazy val ci = command(ciFmt, ciFast, ciSlow)
+      lazy val cleanAll = command(
         "reload",
         "bench/clean",
         "check/clean",
@@ -97,7 +97,7 @@ object Build extends AutoPlugin {
         "scalap/clean",
         "tests/clean"
       )
-      val compileAll = command(
+      lazy val compileAll = command(
         "bench/compile",
         "check/compile",
         "core/compile",
@@ -114,46 +114,46 @@ object Build extends AutoPlugin {
         "tests/compile",
         "tests/test:compile"
       )
-      val fmtAll = "scalafmtFormat"
-      val testAll = command(
+      lazy val fmtAll = "scalafmtFormat"
+      lazy val testAll = command(
         "reload",
         "cleanAll",
         ci
       )
-      val benchAll = command(
+      lazy val benchAll = command(
         "cleanAll",
         "compileAll",
         "bench/jmh:run RscParse RscLink RscOutline RscSemanticdb RscMjar ScalacCompile"
       )
-      val publishAll = command(
+      lazy val publishAll = command(
         "check/publish",
         "mjar/publish",
         "rsc/publish",
         "scalasig/publish",
         "scalap/publish"
       )
-      val publishLocal = command(
+      lazy val publishLocal = command(
         "check/publishLocal",
         "mjar/publishLocal",
         "rsc/publishLocal",
         "scalasig/publishLocal",
         "scalap/publishLocal"
       )
-      val compile = "tests/test:compile"
-      val fastTest = "tests/fast:test"
-      val slowTest = command(
+      lazy val compile = "tests/test:compile"
+      lazy val fastTest = "tests/fast:test"
+      lazy val slowTest = command(
         "tests/slow:test",
         "scalafixTests/test"
       )
-      val test = fastTest
-      val benchParse = "bench/jmh:run RscParse"
-      val benchLink = "bench/jmh:run RscLink"
-      val benchOutline = "bench/jmh:run RscOutline"
-      val benchSemanticdb = "bench/jmh:run RscSemanticdb"
-      val benchMjar = "bench/jmh:run RscMjar"
+      lazy val test = fastTest
+      lazy val benchParse = "bench/jmh:run RscParse"
+      lazy val benchLink = "bench/jmh:run RscLink"
+      lazy val benchOutline = "bench/jmh:run RscOutline"
+      lazy val benchSemanticdb = "bench/jmh:run RscSemanticdb"
+      lazy val benchMjar = "bench/jmh:run RscMjar"
     }
 
-    val isCI = sys.env.contains("CI")
+    lazy val isCI = sys.env.contains("CI")
 
     // https://stackoverflow.com/questions/41229451/how-to-disable-slow-tagged-scalatests-by-default-allow-execution-with-option
     lazy val Fast = config("fast").extend(Test)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -69,6 +69,10 @@ object Build extends AutoPlugin {
         "function/clean",
         "mjar/clean",
         "rsc/clean",
+        "scalafixInput/clean",
+        "scalafixOutput/clean",
+        "scalafixRules/clean",
+        "scalafixTests/clean",
         "scalasig/clean",
         "scalap/clean",
         "tests/clean"
@@ -80,6 +84,11 @@ object Build extends AutoPlugin {
         "function/compile",
         "mjar/compile",
         "rsc/compile",
+        "scalafixInput/compile",
+        "scalafixOutput/compile",
+        "scalafixRules/compile",
+        "scalafixTests/compile",
+        "scalafixTests/test:compile",
         "scalasig/compile",
         "scalap/compile",
         "tests/compile",
@@ -112,7 +121,10 @@ object Build extends AutoPlugin {
       )
       val compile = "tests/test:compile"
       val fastTest = "tests/fast:test"
-      val slowTest = "tests/slow:test"
+      val slowTest = command(
+        "tests/slow:test",
+        "scalafixTests/test"
+      )
       val test = fastTest
       val benchParse = "bench/jmh:run RscParse"
       val benchLink = "bench/jmh:run RscLink"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -18,42 +18,58 @@ object Build extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
   import autoImport._
 
+  private def buildRoot: Path = Paths.get("").toAbsolutePath
+
   private def command(commands: String*): String = command(commands.toList)
   private def command(commands: List[String]): String = {
     commands.map(c => s";$c ").mkString("")
   }
 
-  private def scalafmt(options: String*): Unit = {
-    val projectRoot = Paths.get(".")
-    val dotScalafmt = projectRoot.resolve("./scalafmt")
-    val binScalafmt = projectRoot.resolve("bin/scalafmt")
-    val scalafmtBinary = List(dotScalafmt, binScalafmt).filter(f => exists(f))
-    scalafmtBinary match {
-      case List(scalafmtBinary, _*) =>
-        val command = scalafmtBinary.toString :: options.toList
-        val scalafmt = new java.lang.ProcessBuilder()
-        scalafmt.command(command.asJava)
-        scalafmt.directory(projectRoot.toFile)
-        scalafmt.redirectOutput(Redirect.INHERIT)
-        scalafmt.redirectError(Redirect.INHERIT)
-        val exitcode = scalafmt.start().waitFor()
-        if (exitcode != 0) {
-          sys.error(s"scalafmt --test has failed with code $exitcode")
-        }
-      case Nil =>
-        sys.error("Scalafmt binary not found")
+  private def shellout(command: List[String], cwd: Path): Unit = {
+    val builder = new java.lang.ProcessBuilder()
+    builder.command(command.asJava)
+    builder.directory(cwd.toFile)
+    builder.redirectOutput(Redirect.INHERIT)
+    builder.redirectError(Redirect.INHERIT)
+    val exitcode = builder.start().waitFor()
+    if (exitcode != 0) {
+      val what = command.mkString(" ")
+      sys.error(s"$what in $cwd has failed with code $exitcode")
     }
+  }
+  private def scalafmt(args: List[String], cwd: Path): Unit = {
+    val bin = buildRoot.resolve("bin/scalafmt").toAbsolutePath.toString
+    shellout(bin +: args, cwd)
+  }
+  private def scalafix(args: List[String], cwd: Path): Unit = {
+    val bin = buildRoot.resolve("bin/scalafix").toAbsolutePath.toString
+    shellout(bin +: args, cwd)
   }
 
   object autoImport {
     val scalafmtFormat = taskKey[Unit]("Automatically format all files")
     val scalafmtTest = taskKey[Unit]("Test that all files are formatted")
+    val rewrite = taskKey[Unit]("Rewrite the project to be compatible with Rsc")
 
     def computeScalaVersionFromTravisYml(prefix: String): String = {
       val travisYml = IO.read(file(".travis.yml"))
       val scalaRegex = (prefix + ".\\d+").r
       val scalaMatch = scalaRegex.findFirstMatchIn(travisYml)
       scalaMatch.map(_.group(0)).get
+    }
+
+    def scalafixRscCompat(baseDirectory: File): Unit = {
+      val args = List.newBuilder[String]
+      args += "--tool-classpath"
+      args += buildRoot.resolve("scalafix/rules/target/scala-2.11/classes").toAbsolutePath.toString
+      args += "--classpath"
+      args += baseDirectory.toPath.resolve("target/scala-2.11/classes").toAbsolutePath.toString
+      args += "--sourceroot"
+      args += buildRoot.toAbsolutePath.toString
+      args += "--rules"
+      args += "scala:scalafix.internal.rule.RscCompat"
+      args += baseDirectory.toPath.toAbsolutePath.toString
+      scalafix(args.result, baseDirectory.toPath)
     }
 
     object ui {
@@ -141,7 +157,11 @@ object Build extends AutoPlugin {
   }
 
   override def globalSettings: Seq[Def.Setting[_]] = List(
-    scalafmtFormat := scalafmt("--non-interactive"),
-    scalafmtTest := scalafmt("--test", "--non-interactive", "--quiet")
+    scalafmtFormat := {
+      scalafmt(List("--non-interactive"), buildRoot)
+    },
+    scalafmtTest := {
+      scalafmt(List("--test", "--non-interactive", "--quiet"), buildRoot)
+    }
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,5 +5,4 @@ addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin-shaded" % "0.7.1"
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.6.0-M5")
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.25"

--- a/rsc/src/main/scala/rsc/semanticdb/Semanticdb.scala
+++ b/rsc/src/main/scala/rsc/semanticdb/Semanticdb.scala
@@ -300,7 +300,7 @@ final class Semanticdb private (
                       case s.TypeSignature(_, _, s.TypeRef(_, sym, _)) =>
                         sym
                       case other =>
-                        crash(other.toSignatureMessage.toProtoString)
+                        crash(other.asMessage.toProtoString)
                     }
                     val aliasDeep = superClass(List(aliasShallow))
                     if (aliasShallow != aliasDeep) aliasDeep

--- a/scalafix/input/src/main/scala/rsc/tests/RscCompat.scala
+++ b/scalafix/input/src/main/scala/rsc/tests/RscCompat.scala
@@ -96,6 +96,8 @@ object RscCompat_Test {
     // val repeatedType = ??? : ((Any*) => Any)
   }
 
+  implicit val x: Int = 42
+
   class Bugs {
     val Either = scala.util.Either
 
@@ -125,5 +127,7 @@ object RscCompat_Test {
     val more1 = new { var x = 42 }
     val more2 = new { def foo(implicit x: Int, y: Int) = 42 }
     val more3 = new { implicit def bar = 42 }
+
+    implicit val crazy = implicitly[Int]
   }
 }

--- a/scalafix/input/src/main/scala/rsc/tests/RscCompat.scala
+++ b/scalafix/input/src/main/scala/rsc/tests/RscCompat.scala
@@ -1,0 +1,129 @@
+/*
+rules = "scala:scalafix.internal.rule.RscCompat"
+ */
+package rsc.tests
+
+import java.util.Base64
+import scala.language.existentials
+import scala.language.higherKinds
+
+object RscCompat_Test {
+  class Basic {
+    def x1 = 42
+    val x2 = ""
+    final val x3 = ""
+    var x4 = ""
+  }
+
+  class Visibility {
+    private def x1 = ""
+    private[this] def x2 = ""
+    private[rsc] def x3 = ""
+    protected def x4 = ""
+    protected[this] def x5 = ""
+    protected[rsc] def x6 = ""
+  }
+
+  object TypesHelpers {
+    class C
+    class E {
+      class C
+    }
+    class P {
+      class C
+      val c: C = ???
+    }
+    val p = new P
+    val c = p.c
+    trait A
+    trait B
+    class ann extends scala.annotation.StaticAnnotation
+    class H[M[_]]
+  }
+
+  trait TypesBase {
+    class X
+    val x: X = ???
+  }
+
+  class Types[T] extends TypesBase {
+    import TypesHelpers._
+    override val x: X = new X
+
+    val typeRef1 = ??? : C
+    val typeRef2 = ??? : p.C
+    val typeRef3 = ??? : E#C
+    val typeRef4 = ??? : List[Int]
+    val typeRef5 = ??? : X
+    val typeRef6 = ??? : T
+    val typeRef7 = ??? : () => T
+    val typeRef8 = ??? : T => T
+    val typeRef9 = ??? : (T, T) => T
+    val typeRef10 = ??? : (T, T)
+
+    val singleType1 = ??? : c.type
+    val singleType2 = ??? : p.c.type
+    val Either = ??? : scala.util.Either.type
+
+    val thisType1 = ??? : this.type
+    val thisType2 = ??? : Types.this.type
+
+    // FIXME: https://github.com/twitter/rsc/issues/143
+    // val superType1 = ??? : super.x.type
+    // val superType2 = ??? : super[TypesBase].x.type
+    // val superType3 = ??? : Types.super[TypesBase].x.type
+
+    // FIXME: https://github.com/twitter/rsc/issues/145
+    // val constantType1 = ??? : 42.type
+
+    val compoundType1 = ??? : { def k: Int }
+    val compoundType2 = ??? : A with B
+    val compoundType3 = ??? : A with B { def k: Int }
+    val compoundType4 = new { def k: Int = ??? }
+    val compoundType5 = new A with B
+    val compoundType6 = new A with B { def k: Int = ??? }
+    val compoundType7 = ??? : A with (List[T] forSome { type T }) with B
+
+    val annType1 = ??? : C @ann
+
+    val existentialType1 = ??? : T forSome { type T }
+    val existentialType2 = ??? : List[_]
+
+    val universalType1 = ??? : H[({ type L[U] = List[U] })#L]
+
+    val byNameType = ??? : ((=> Any) => Any)
+    // FIXME: https://github.com/twitter/rsc/issues/144
+    // val repeatedType = ??? : ((Any*) => Any)
+  }
+
+  class Bugs {
+    val Either = scala.util.Either
+
+    implicit def order[T] = new Ordering[List[T]] {
+      def compare(a: List[T], b: List[T]): Int = ???
+    }
+
+    val gauges = {
+      val local1 = 42
+      val local2 = 43
+      List(local1, local2)
+    }
+
+    val clazz = Class.forName("foo.Bar")
+
+    val compound = ??? : { def m(x: Int): Int }
+
+    val loaded = List[Class[_]]()
+
+    val ti: Types[Int] = ???
+    val innerClass1 = new Types[String]().x
+    val innerClass2 = ??? : Types[Int]#X
+    val innerClass3 = ti.x
+    val innerClass4 = Base64.getMimeDecoder
+
+    val param = new { lazy val default = true }
+    val more1 = new { var x = 42 }
+    val more2 = new { def foo(implicit x: Int, y: Int) = 42 }
+    val more3 = new { implicit def bar = 42 }
+  }
+}

--- a/scalafix/output/src/main/scala/rsc/tests/RscCompat.scala
+++ b/scalafix/output/src/main/scala/rsc/tests/RscCompat.scala
@@ -1,0 +1,126 @@
+package rsc.tests
+
+import java.util.Base64
+import scala.language.existentials
+import scala.language.higherKinds
+
+object RscCompat_Test {
+  class Basic {
+    def x1: _root_.scala.Int = 42
+    val x2: _root_.java.lang.String = ""
+    final val x3 = ""
+    var x4: _root_.java.lang.String = ""
+  }
+
+  class Visibility {
+    private def x1: _root_.java.lang.String = ""
+    private[this] def x2: _root_.java.lang.String = ""
+    private[rsc] def x3: _root_.java.lang.String = ""
+    protected def x4: _root_.java.lang.String = ""
+    protected[this] def x5: _root_.java.lang.String = ""
+    protected[rsc] def x6: _root_.java.lang.String = ""
+  }
+
+  object TypesHelpers {
+    class C
+    class E {
+      class C
+    }
+    class P {
+      class C
+      val c: C = ???
+    }
+    val p: _root_.rsc.tests.RscCompat_Test.TypesHelpers.P = new P
+    val c: _root_.rsc.tests.RscCompat_Test.TypesHelpers.p.C = p.c
+    trait A
+    trait B
+    class ann extends scala.annotation.StaticAnnotation
+    class H[M[_]]
+  }
+
+  trait TypesBase {
+    class X
+    val x: X = ???
+  }
+
+  class Types[T] extends TypesBase {
+    import TypesHelpers._
+    override val x: X = new X
+
+    val typeRef1: _root_.rsc.tests.RscCompat_Test.TypesHelpers.C = ??? : C
+    val typeRef2: _root_.rsc.tests.RscCompat_Test.TypesHelpers.p.C = ??? : p.C
+    val typeRef3: _root_.rsc.tests.RscCompat_Test.TypesHelpers.E#C = ??? : E#C
+    val typeRef4: _root_.scala.`package`.List[_root_.scala.Int] = ??? : List[Int]
+    val typeRef5: Types.this.X = ??? : X
+    val typeRef6: T = ??? : T
+    val typeRef7: _root_.scala.Function0[T] = ??? : () => T
+    val typeRef8: _root_.scala.Function1[T, T] = ??? : T => T
+    val typeRef9: _root_.scala.Function2[T, T, T] = ??? : (T, T) => T
+    val typeRef10: _root_.scala.Tuple2[T, T] = ??? : (T, T)
+
+    val singleType1: _root_.rsc.tests.RscCompat_Test.TypesHelpers.c.type = ??? : c.type
+    val singleType2: _root_.rsc.tests.RscCompat_Test.TypesHelpers.p.c.type = ??? : p.c.type
+    val Either: _root_.scala.util.Either.type = ??? : scala.util.Either.type
+
+    val thisType1: Types.this.type = ??? : this.type
+    val thisType2: Types.this.type = ??? : Types.this.type
+
+    // FIXME: https://github.com/twitter/rsc/issues/143
+    // val superType1 = ??? : super.x.type
+    // val superType2 = ??? : super[TypesBase].x.type
+    // val superType3 = ??? : Types.super[TypesBase].x.type
+
+    // FIXME: https://github.com/twitter/rsc/issues/145
+    // val constantType1 = ??? : 42.type
+
+    val compoundType1: _root_.scala.AnyRef { def k: _root_.scala.Int } = ??? : { def k: Int }
+    val compoundType2: _root_.rsc.tests.RscCompat_Test.TypesHelpers.A with _root_.rsc.tests.RscCompat_Test.TypesHelpers.B = ??? : A with B
+    val compoundType3: _root_.rsc.tests.RscCompat_Test.TypesHelpers.A with _root_.rsc.tests.RscCompat_Test.TypesHelpers.B { def k: _root_.scala.Int } = ??? : A with B { def k: Int }
+    val compoundType4: _root_.scala.AnyRef { def k: _root_.scala.Int } = new { def k: Int = ??? }
+    val compoundType5: _root_.scala.AnyRef with _root_.rsc.tests.RscCompat_Test.TypesHelpers.A with _root_.rsc.tests.RscCompat_Test.TypesHelpers.B = new A with B
+    val compoundType6: _root_.scala.AnyRef with _root_.rsc.tests.RscCompat_Test.TypesHelpers.A with _root_.rsc.tests.RscCompat_Test.TypesHelpers.B { def k: _root_.scala.Int } = new A with B { def k: Int = ??? }
+    val compoundType7: _root_.rsc.tests.RscCompat_Test.TypesHelpers.A with (_root_.scala.collection.immutable.List[T] forSome { type T }) with _root_.rsc.tests.RscCompat_Test.TypesHelpers.B = ??? : A with (List[T] forSome { type T }) with B
+
+    val annType1: _root_.rsc.tests.RscCompat_Test.TypesHelpers.C @_root_.rsc.tests.RscCompat_Test.TypesHelpers.ann = ??? : C @ann
+
+    val existentialType1: _root_.scala.Any = ??? : T forSome { type T }
+    val existentialType2: _root_.scala.collection.immutable.List[_root_.scala.Any] = ??? : List[_]
+
+    val universalType1: _root_.rsc.tests.RscCompat_Test.TypesHelpers.H[({ type λ[U] = _root_.scala.collection.immutable.List[U] })#λ] = ??? : H[({ type L[U] = List[U] })#L]
+
+    val byNameType: (=> _root_.scala.Any) => _root_.scala.Any = ??? : ((=> Any) => Any)
+    // FIXME: https://github.com/twitter/rsc/issues/144
+    // val repeatedType = ??? : ((Any*) => Any)
+  }
+
+  class Bugs {
+    val Either: _root_.scala.util.Either.type = scala.util.Either
+
+    implicit def order[T]: _root_.java.lang.Object with _root_.scala.`package`.Ordering[_root_.scala.`package`.List[T]] = new Ordering[List[T]] {
+      def compare(a: List[T], b: List[T]): Int = ???
+    }
+
+    val gauges: _root_.scala.collection.immutable.List[_root_.scala.Int] = {
+      val local1 = 42
+      val local2 = 43
+      List(local1, local2)
+    }
+
+    val clazz: _root_.java.lang.Class[T1] forSome { type T1 } = Class.forName("foo.Bar")
+
+    val compound: _root_.scala.AnyRef { def m(x: _root_.scala.Int): _root_.scala.Int } = ??? : { def m(x: Int): Int }
+
+    val loaded: _root_.scala.collection.immutable.List[_root_.java.lang.Class[T1] forSome { type T1 }] = List[Class[_]]()
+
+    val ti: Types[Int] = ???
+    val innerClass1: _root_.rsc.tests.RscCompat_Test.Types[_root_.scala.Predef.String]#X = new Types[String]().x
+    val innerClass2: _root_.rsc.tests.RscCompat_Test.Types[_root_.scala.Int]#X = ??? : Types[Int]#X
+    val innerClass3: Bugs.this.ti.X = ti.x
+    val innerClass4: _root_.java.util.Base64.Decoder = Base64.getMimeDecoder
+
+    val param: _root_.scala.AnyRef { val default: _root_.scala.Boolean } = new { lazy val default = true }
+    val more1: _root_.scala.AnyRef { var x: _root_.scala.Int;  } = new { var x = 42 }
+    val more2: _root_.scala.AnyRef { def foo(implicit x: _root_.scala.Int, y: _root_.scala.Int): _root_.scala.Int } = new { def foo(implicit x: Int, y: Int) = 42 }
+    val more3: _root_.scala.AnyRef { def bar: _root_.scala.Int } = new { implicit def bar = 42 }
+  }
+}

--- a/scalafix/output/src/main/scala/rsc/tests/RscCompat.scala
+++ b/scalafix/output/src/main/scala/rsc/tests/RscCompat.scala
@@ -93,6 +93,8 @@ object RscCompat_Test {
     // val repeatedType = ??? : ((Any*) => Any)
   }
 
+  implicit val x: Int = 42
+
   class Bugs {
     val Either: _root_.scala.util.Either.type = scala.util.Either
 
@@ -122,5 +124,7 @@ object RscCompat_Test {
     val more1: _root_.scala.AnyRef { var x: _root_.scala.Int;  } = new { var x = 42 }
     val more2: _root_.scala.AnyRef { def foo(implicit x: _root_.scala.Int, y: _root_.scala.Int): _root_.scala.Int } = new { def foo(implicit x: Int, y: Int) = 42 }
     val more3: _root_.scala.AnyRef { def bar: _root_.scala.Int } = new { implicit def bar = 42 }
+
+    implicit val crazy = implicitly[Int]
   }
 }

--- a/scalafix/rules/src/main/scala/scalafix/internal/rule/RscCompat.scala
+++ b/scalafix/rules/src/main/scala/scalafix/internal/rule/RscCompat.scala
@@ -248,6 +248,7 @@ class TypePrinter(env: Env) {
           opt(utpe)(normal)
           rep(" forSome { ", decls.infos, "; ", " }")(pprint)
         case s.UniversalType(tparams, utpe) =>
+          // FIXME: https://github.com/twitter/rsc/issues/150
           out.append("({ type λ")
           tparams.infos.foreach(notes.append)
           rep("[", tparams.infos, ", ", "] = ")(pprint)

--- a/scalafix/rules/src/main/scala/scalafix/internal/rule/RscCompat.scala
+++ b/scalafix/rules/src/main/scala/scalafix/internal/rule/RscCompat.scala
@@ -1,6 +1,7 @@
 // Copyright (c) 2017-2018 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 // NOTE: This file has been partially copy/pasted from scalacenter/scalafix.
+// NOTE: This file has been partially copy/pasted from scalameta/scalameta.
 package scalafix.internal.rule
 
 import java.io._
@@ -65,6 +66,7 @@ case class RscCompat(index: SemanticdbIndex)
         case Defn.Def(_, name, _, _, None, body) =>
           append(env, name, body)
         case _ =>
+          // FIXME: https://github.com/twitter/rsc/issues/149
           ()
       }
     }

--- a/scalafix/rules/src/main/scala/scalafix/internal/rule/RscCompat.scala
+++ b/scalafix/rules/src/main/scala/scalafix/internal/rule/RscCompat.scala
@@ -76,6 +76,10 @@ case class RscCompat(index: SemanticdbIndex)
 
   private def ascribeReturnType(ctx: RuleCtx, target: RewriteTarget): Patch = {
     try {
+      target.body match {
+        case Term.ApplyType(Term.Name("implicitly"), _) =>
+          Patch.empty
+        case _ =>
       val symbol = {
         val result = target.name.symbol.get.syntax
         assert(result.isGlobal)
@@ -114,6 +118,7 @@ case class RscCompat(index: SemanticdbIndex)
         case other =>
           val details = other.toSignatureMessage.toProtoString
           sys.error(s"unsupported outline: $details")
+      }
       }
     } catch {
       case ex: Throwable =>

--- a/scalafix/rules/src/main/scala/scalafix/internal/rule/RscCompat.scala
+++ b/scalafix/rules/src/main/scala/scalafix/internal/rule/RscCompat.scala
@@ -1,0 +1,537 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+// NOTE: This file has been partially copy/pasted from scalacenter/scalafix.
+package scalafix.internal.rule
+
+import java.io._
+import java.nio.charset.StandardCharsets.UTF_8
+import scala.collection.mutable
+import scala.meta._
+import scala.meta.contrib._
+import scala.meta.internal.{semanticdb => s}
+import scala.meta.internal.semanticdb.Scala._
+import scala.meta.internal.semanticdb.Scala.{Descriptor => d}
+import scala.meta.internal.semanticdb.SymbolInformation.{Kind => k}
+import scala.meta.internal.semanticdb.SymbolInformation.{Property => p}
+import scalafix.internal.patch.DocSemanticdbIndex
+import scalafix.internal.util._
+import scalafix.lint.LintMessage
+import scalafix.rule._
+import scalafix.syntax._
+import scalafix.util.TokenOps
+import scalafix.v0._
+
+// ============ Introduction ============
+//
+// RscCompat is a Scalafix rule that rewrites Scala codebases
+// to be compatible with Rsc. At the moment, it is far from perfect -
+// for details, see https://github.com/twitter/rsc/labels/Scalafix.
+
+case class RscCompat(index: SemanticdbIndex) extends SemanticRule(index, "RscCompat") {
+  override def fix(ctx: RuleCtx): Patch = {
+    val targets = collectRewriteTargets(ctx.tree)
+    targets.map(ascribeReturnType(ctx, _)).asPatch
+  }
+
+  private case class RewriteTarget(env: Env, name: Name, body: Term)
+
+  private def collectRewriteTargets(tree: Tree): List[RewriteTarget] = {
+    val buf = List.newBuilder[RewriteTarget]
+    def append(env: Env, name: Name, body: Term): Unit = {
+      buf += RewriteTarget(env, name, body)
+    }
+    def loop(env: Env, tree: Tree): Unit = {
+      // FIXME: https://github.com/twitter/rsc/issues/140
+      tree match {
+        case Source(stats) =>
+          stats.foreach(loop(env, _))
+        case Pkg(_, stats) =>
+          stats.foreach(loop(env, _))
+        case Pkg.Object(_, name, templ) =>
+          loop(TemplateScope(name.symbol.get.syntax) :: env, templ)
+        case Defn.Class(_, name, _, _, templ) =>
+          loop(TemplateScope(name.symbol.get.syntax) :: env, templ)
+        case Defn.Trait(_, name, _, _, templ) =>
+          loop(TemplateScope(name.symbol.get.syntax) :: env, templ)
+        case Defn.Object(_, name, templ) =>
+          loop(TemplateScope(name.symbol.get.syntax) :: env, templ)
+        case Template(early, _, _, stats) =>
+          (early ++ stats).foreach(loop(env, _))
+        case Defn.Val(_, List(Pat.Var(name)), None, body) =>
+          append(env, name, body)
+        case Defn.Var(_, List(Pat.Var(name)), None, Some(body)) =>
+          append(env, name, body)
+        case Defn.Def(_, name, _, _, None, body) =>
+          append(env, name, body)
+        case _ =>
+          ()
+      }
+    }
+    loop(Env(Nil), tree)
+    buf.result
+  }
+
+  private def ascribeReturnType(ctx: RuleCtx, target: RewriteTarget): Patch = {
+    try {
+      val symbol = {
+        val result = target.name.symbol.get.syntax
+        assert(result.isGlobal)
+        result
+      }
+      val outline = {
+        val symbol = target.name.symbol.get.syntax
+        assert(symbol.isGlobal)
+        val docInfos = index.asInstanceOf[DocSemanticdbIndex].doc.sdoc.symbols
+        val info = docInfos.find(_.symbol == symbol).get
+        info.signature
+      }
+      outline match {
+        case s.MethodSignature(_, _, _: s.ConstantType) =>
+          Patch.empty
+        case s.MethodSignature(_, _, returnType) =>
+          val token = {
+            val start = target.name.tokens.head
+            val end = target.body.tokens.head
+            val slice = ctx.tokenList.slice(start, end)
+            slice.reverse.find(x => !x.is[Token.Equals] && !x.is[Trivia]).get
+          }
+          val ascription = {
+            val returnTypeString = {
+              val printer = new TypePrinter(target.env)
+              printer.pprint(returnType)
+              printer.toString
+            }
+            if (TokenOps.needsLeadingSpaceBeforeColon(token)) s" : $returnTypeString"
+            else s": $returnTypeString"
+          }
+          ctx.addRight(token, ascription)
+        case other =>
+          sys.error(s"unsupported outline: ${other.toSignatureMessage.toProtoString}")
+      }
+    } catch {
+      case ex: Throwable =>
+        val sw = new java.io.StringWriter()
+        ex.printStackTrace(new PrintWriter(sw))
+        val category = LintCategory.error("")
+        Patch.lint(LintMessage(sw.toString, target.name.pos, category))
+    }
+  }
+}
+
+// ============ Name resolution ============
+//
+// The code below represents a minimal framework for scopes that is required
+// for correct type printing.
+//
+// At the moment, we don't have to track all kinds of scopes - only the ones
+// that are necessary to compute enclosing templates (see below on why this is necessary).
+// FIXME: https://github.com/twitter/rsc/issues/141
+
+case class Env(scopes: List[Scope]) {
+  def ::(scope: Scope): Env = {
+    Env(scope :: scopes)
+  }
+
+  def lookupThis(name: String): String = {
+    def loop(scopes: List[Scope]): String = {
+      scopes match {
+        case head :: tail =>
+          val sym = head.lookupThis(name)
+          if (sym.isNone) loop(tail)
+          else sym
+        case Nil =>
+          Symbols.None
+      }
+    }
+    loop(scopes)
+  }
+}
+
+sealed trait Scope {
+  def lookupThis(name: String): String
+}
+
+case class TemplateScope(sym: String) extends Scope {
+  def lookupThis(name: String): String = {
+    if (sym.desc.name == name) sym
+    else Symbols.None
+  }
+}
+
+// ============ Type printing ============
+//
+// Our design goal is to achieve precise enough prettyprinting without
+// needing a full-fledged symbol table. Surprisingly, so far this
+// seems to be possible.
+
+class TypePrinter(env: Env) {
+  private val baos = new ByteArrayOutputStream
+  private val out = new PrintStream(baos, true, UTF_8.name)
+  override def toString = new String(baos.toByteArray, UTF_8)
+
+  def pprint(tpe: s.Type): Unit = {
+    def prefix(tpe: s.Type): Unit = {
+      tpe match {
+        case s.TypeRef(pre, sym, args) =>
+          if (sym.startsWith("scala/Function") &&
+              args.exists(_.isInstanceOf[s.ByNameType])) {
+            var params :+ ret = args
+            if (params.length != 1) out.print("(")
+            rep(params, ", ") { param =>
+              // FIXME: https://github.com/twitter/rsc/issues/142
+              out.print("(")
+              normal(param)
+              out.print(")")
+            }
+            if (params.length != 1) out.print(")")
+            out.print(" => ")
+            normal(ret)
+          } else {
+            val prettyPre = if (pre == s.NoType) sym.trivialPrefix else pre
+            prettyPre match {
+              case _: s.SingleType | _: s.ThisType | _: s.SuperType =>
+                prefix(prettyPre)
+                out.print(".")
+              case s.NoType =>
+                ()
+              case _ =>
+                prefix(prettyPre)
+                out.print("#")
+            }
+            pprint(sym)
+            rep("[", args, ", ", "]")(normal)
+          }
+        case s.SingleType(pre, sym) =>
+          val prettyPre = if (pre == s.NoType) sym.trivialPrefix else pre
+          opt(prettyPre, ".")(prefix)
+          pprint(sym)
+        case s.ThisType(sym) =>
+          opt(sym, ".")(pprint)
+          out.print("this")
+        case s.SuperType(pre, sym) =>
+          opt(pre, ".")(prefix)
+          out.print("super")
+          opt("[", sym, "]")(pprint)
+        case s.WithType(types) =>
+          rep(types, " with ") { tpe =>
+            // FIXME: https://github.com/twitter/rsc/issues/142
+            val needsParens = tpe.isInstanceOf[s.ExistentialType]
+            if (needsParens) out.print("(")
+            normal(tpe)
+            if (needsParens) out.print(")")
+          }
+        case s.StructuralType(utpe, decls) =>
+          decls.infos.foreach(notes.append)
+          opt(utpe)(normal)
+          if (decls.infos.nonEmpty) {
+            rep(" { ", decls.infos, "; ", " }")(pprint)
+          } else {
+            utpe match {
+              case s.WithType(tpes) if tpes.length > 1 => ()
+              case _ => out.print(" {}")
+            }
+          }
+        case s.AnnotatedType(anns, utpe) =>
+          opt(utpe)(normal)
+          out.print(" ")
+          rep(anns, " ", "")(pprint)
+        case s.ExistentialType(utpe, decls) =>
+          decls.infos.foreach(notes.append)
+          opt(utpe)(normal)
+          rep(" forSome { ", decls.infos, "; ", " }")(pprint)
+        case s.UniversalType(tparams, utpe) =>
+          out.append("({ type λ")
+          tparams.infos.foreach(notes.append)
+          rep("[", tparams.infos, ", ", "] = ")(pprint)
+          opt(utpe)(normal)
+          out.append(" })#λ")
+        case s.ByNameType(utpe) =>
+          out.print("=> ")
+          opt(utpe)(normal)
+        case s.RepeatedType(utpe) =>
+          opt(utpe)(normal)
+          out.print("*")
+        case _: s.ConstantType | _: s.IntersectionType | _: s.UnionType | s.NoType =>
+          sys.error(s"unsupported type: ${tpe.toTypeMessage.toProtoString}")
+      }
+    }
+    def normal(tpe: s.Type): Unit = {
+      tpe match {
+        case _: s.SingleType | _: s.ThisType | _: s.SuperType =>
+          prefix(tpe)
+          out.print(".type")
+        case _ =>
+          prefix(tpe)
+      }
+    }
+    normal(tpe)
+  }
+
+  private def pprint(sym: String): Unit = {
+    val printableName = {
+      val sourceName = notes.get(sym).map(_.name)
+      sourceName match {
+        case Some(name) =>
+          if (name == "") {
+            sys.error(s"unsupported symbol: $sym")
+          } else if (name == "_" || name.startsWith("?")) {
+            gensymCache.getOrElseUpdate(sym, gensym("T"))
+          } else {
+            name
+          }
+        case None =>
+          if (sym.isGlobal) sym.desc.name
+          else sym
+      }
+    }
+    if (ScalaKeywords.all(printableName)) out.print("`")
+    out.print(printableName)
+    if (ScalaKeywords.all(printableName)) out.print("`")
+  }
+
+  private def pprint(info: s.SymbolInformation): Unit = {
+    if (info.kind == k.METHOD && info.name.endsWith("_=")) return
+    notes.append(info)
+    rep(info.annotations, " ", " ")(pprint)
+    if (info.has(p.COVARIANT)) out.print("+")
+    if (info.has(p.CONTRAVARIANT)) out.print("-")
+    info.kind match {
+      case k.METHOD if info.has(p.VAL) => out.print("val ")
+      case k.METHOD if info.has(p.VAR) => out.print("var ")
+      case k.METHOD => out.print("def ")
+      case k.TYPE => out.print("type ")
+      case k.PARAMETER => out.print("")
+      case k.TYPE_PARAMETER => out.print("")
+      case other => sys.error(s"unsupported info: ${info.toProtoString}")
+    }
+    pprint(info.symbol)
+    info.signature match {
+      case s.MethodSignature(tparams, paramss, res) =>
+        rep("[", tparams.infos, ", ", "]")(pprint)
+        rep("(", paramss, ")(", ")") { params =>
+          if (params.infos.exists(_.has(p.IMPLICIT))) out.print("implicit ")
+          rep(params.infos, ", ")(pprint)
+        }
+        opt(": ", res)(pprint)
+      case s.TypeSignature(tparams, lo, hi) =>
+        rep("[", tparams.infos, ", ", "]")(pprint)
+        if (lo != hi) {
+          lo match {
+            case s.TypeRef(s.NoType, "scala/Nothing#", Nil) => ()
+            case lo => opt(" >: ", lo)(pprint)
+          }
+          hi match {
+            case s.TypeRef(s.NoType, "scala/Any#", Nil) => ()
+            case hi => opt(" <: ", hi)(pprint)
+          }
+        } else {
+          val alias = lo
+          opt(" = ", alias)(pprint)
+        }
+      case s.ValueSignature(tpe) =>
+        out.print(": ")
+        pprint(tpe)
+      case other =>
+        sys.error(s"unsupported signature: ${other.toSignatureMessage.toProtoString}")
+    }
+  }
+
+  private def pprint(ann: s.Annotation): Unit = {
+    out.print("@")
+    ann.tpe match {
+      case s.NoType =>
+        sys.error(s"unsupported annotation: ${ann.toProtoString}")
+      case tpe =>
+        pprint(tpe)
+    }
+  }
+
+  private val notes = new InfoNotes
+  private class InfoNotes {
+    private val map = mutable.Map[String, s.SymbolInformation]()
+    def append(info: s.SymbolInformation): Unit = map(info.symbol) = info
+    def apply(sym: String): s.SymbolInformation = map(sym)
+    def get(sym: String): Option[s.SymbolInformation] = map.get(sym)
+  }
+
+  private val gensymCache = mutable.Map[String, String]()
+  private val gensym = new Gensym
+  private class Gensym {
+    private val counters = mutable.Map[String, Int]()
+    def apply(prefix: String): String = {
+      val nextCounter = counters.getOrElse(prefix, 0) + 1
+      counters(prefix) = nextCounter
+      prefix + nextCounter
+    }
+  }
+
+  private implicit class SymbolOps(sym: String) {
+    def trivialPrefix: s.Type = {
+      if (sym.isRootPackage) {
+        s.NoType
+      } else if (sym.isEmptyPackage) {
+        s.NoType
+      } else if (sym.desc.isParameter || sym.desc.isTypeParameter) {
+        s.NoType
+      } else {
+        sym.owner.desc match {
+          case _: d.Term | _: d.Package =>
+            s.SingleType(s.NoType, sym.owner)
+          case d.Type(name) =>
+            val thisSym = env.lookupThis(name)
+            if (sym.owner == thisSym) {
+              s.ThisType(sym.owner)
+            } else {
+              // NOTE: This is an exotic case of referencing a Java static inner class.
+              // Check out innerClass4 in the test suite for an example.
+              s.SingleType(s.NoType, sym.owner)
+            }
+          case _ =>
+            s.NoType
+        }
+      }
+    }
+  }
+
+  private def rep[T](pre: String, xs: Seq[T], sep: String, suf: String)(f: T => Unit): Unit = {
+    if (xs.nonEmpty) {
+      out.print(pre)
+      rep(xs, sep)(f)
+      out.print(suf)
+    }
+  }
+
+  private def rep[T](pre: String, xs: Seq[T], sep: String)(f: T => Unit): Unit = {
+    rep(pre, xs, sep, "")(f)
+  }
+
+  private def rep[T](xs: Seq[T], sep: String, suf: String)(f: T => Unit): Unit = {
+    rep("", xs, sep, suf)(f)
+  }
+
+  private def rep[T](xs: Seq[T], sep: String)(f: T => Unit): Unit = {
+    xs.zipWithIndex.foreach {
+      case (x, i) =>
+        if (i != 0) out.print(sep)
+        f(x)
+    }
+  }
+
+  private def opt[T](pre: String, xs: Option[T], suf: String)(f: T => Unit): Unit = {
+    xs.foreach { x =>
+      out.print(pre)
+      f(x)
+      out.print(suf)
+    }
+  }
+
+  private def opt[T](pre: String, xs: Option[T])(f: T => Unit): Unit = {
+    opt(pre, xs, "")(f)
+  }
+
+  private def opt[T](pre: String, xs: s.Type)(f: s.Type => Unit): Unit = {
+    opt(pre, if (xs.nonEmpty) Some(xs) else None)(f)
+  }
+
+  private def opt[T](pre: String, xs: s.Signature)(f: s.Signature => Unit): Unit = {
+    opt(pre, if (xs.nonEmpty) Some(xs) else None)(f)
+  }
+
+  private def opt[T](xs: Option[T], suf: String)(f: T => Unit): Unit = {
+    opt("", xs, suf)(f)
+  }
+
+  private def opt[T](xs: s.Type, suf: String)(f: s.Type => Unit): Unit = {
+    opt("", if (xs.nonEmpty) Some(xs) else None, suf)(f)
+  }
+
+  private def opt[T](xs: s.Signature, suf: String)(f: s.Signature => Unit): Unit = {
+    opt("", if (xs.nonEmpty) Some(xs) else None, suf)(f)
+  }
+
+  private def opt[T](xs: s.Type)(f: s.Type => Unit): Unit = {
+    opt("", if (xs.nonEmpty) Some(xs) else None, "")(f)
+  }
+
+  private def opt[T](xs: s.Signature)(f: s.Signature => Unit): Unit = {
+    opt("", if (xs.nonEmpty) Some(xs) else None, "")(f)
+  }
+
+  private def opt[T](xs: Option[T])(f: T => Unit): Unit = {
+    opt("", xs, "")(f)
+  }
+
+  private def opt(pre: String, s: String, suf: String)(f: String => Unit): Unit = {
+    if (s.nonEmpty) {
+      out.print(pre)
+      f(s)
+      out.print(suf)
+    }
+  }
+
+  private def opt(s: String, suf: String)(f: String => Unit): Unit = {
+    opt("", s, suf)(f)
+  }
+
+  private def opt(s: String)(f: String => Unit): Unit = {
+    opt("", s, "")(f)
+  }
+}
+
+object ScalaKeywords {
+  val all: Set[String] = {
+    val result = mutable.Set[String]()
+    result += "abstract"
+    result += "case"
+    result += "catch"
+    result += "class"
+    result += "def"
+    result += "do"
+    result += "else"
+    result += "extends"
+    result += "false"
+    result += "final"
+    result += "finally"
+    result += "for"
+    result += "forSome"
+    result += "if"
+    result += "implicit"
+    result += "import"
+    result += "lazy"
+    result += "match"
+    result += "new"
+    result += "null"
+    result += "object"
+    result += "override"
+    result += "package"
+    result += "private"
+    result += "protected"
+    result += "return"
+    result += "sealed"
+    result += "super"
+    result += "this"
+    result += "throw"
+    result += "trait"
+    result += "try"
+    result += "true"
+    result += "type"
+    result += "val"
+    result += "var"
+    result += "while"
+    result += "with"
+    result += "yield"
+    result += "_"
+    result += ":"
+    result += "="
+    result += "=>"
+    result += "⇒"
+    result += "<-"
+    result += "←"
+    result += "<:"
+    result += "<%"
+    result += ">:"
+    result += "#"
+    result += "@"
+    result.toSet
+  }
+}

--- a/scalafix/rules/src/main/scala/scalafix/internal/rule/RscCompat.scala
+++ b/scalafix/rules/src/main/scala/scalafix/internal/rule/RscCompat.scala
@@ -352,8 +352,7 @@ class TypePrinter(env: Env) {
     }
   }
 
-  private val notes = new InfoNotes
-  private class InfoNotes {
+  private object notes {
     private val map = mutable.Map[String, s.SymbolInformation]()
     def append(info: s.SymbolInformation): Unit = map(info.symbol) = info
     def apply(sym: String): s.SymbolInformation = map(sym)
@@ -361,8 +360,7 @@ class TypePrinter(env: Env) {
   }
 
   private val gensymCache = mutable.Map[String, String]()
-  private val gensym = new Gensym
-  private class Gensym {
+  private object gensym {
     private val counters = mutable.Map[String, Int]()
     def apply(prefix: String): String = {
       val nextCounter = counters.getOrElse(prefix, 0) + 1
@@ -372,6 +370,8 @@ class TypePrinter(env: Env) {
   }
 
   private implicit class SymbolOps(sym: String) {
+    // NOTE: See https://github.com/scalameta/scalameta/blob/master/semanticdb/semanticdb3/semanticdb3.md#scala-type
+    // for an explanation of what is a trivial prefix.
     def trivialPrefix: s.Type = {
       if (sym.isRootPackage) {
         s.NoType

--- a/scalafix/tests/src/test/resources/scalafix-testkit.properties
+++ b/scalafix/tests/src/test/resources/scalafix-testkit.properties
@@ -1,0 +1,3 @@
+inputSourceDirectories=scalafix/input
+outputSourceDirectories=scalafix/output
+inputClasspath=scalafix/input/target/scala-2.11/classes

--- a/scalafix/tests/src/test/scala/rsc/tests/ScalafixTests.scala
+++ b/scalafix/tests/src/test/scala/rsc/tests/ScalafixTests.scala
@@ -1,0 +1,7 @@
+package rsc.tests
+
+import scalafix.testkit._
+
+class ScalafixTests extends SemanticRuleSuite {
+  runAllTests()
+}


### PR DESCRIPTION
To scale out to bigger codebases, we implemented a dedicated Scalafix rule that automatically ascribes return types to vals, vars and defs. This way, early adopters won't need to figure out how to make Rsc applicable to their codebases.