### PR TITLE
Add a scalafix rule to make synthetics explicit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -261,5 +261,5 @@ lazy val semanticdbSettings = Def.settings(
   scalacOptions += "-Yrangepos",
   scalacOptions += "-P:semanticdb:text:off",
   scalacOptions += "-P:semanticdb:symbols:on",
-  scalacOptions += "-P:semanticdb:synthetics:off"
+  scalacOptions += "-P:semanticdb:synthetics:on"
 )

--- a/rsc/src/main/scala/rsc/pretty/Printer.scala
+++ b/rsc/src/main/scala/rsc/pretty/Printer.scala
@@ -160,6 +160,8 @@ class Printer {
 
   override def toString = sb.toString
 
+  def reset(): Unit = sb = new StringBuilder
+
   trait Wrap {
     def prefix: Unit = ()
     def suffix: Unit = ()

--- a/rsc/src/main/scala/rsc/pretty/Printer.scala
+++ b/rsc/src/main/scala/rsc/pretty/Printer.scala
@@ -160,8 +160,6 @@ class Printer {
 
   override def toString = sb.toString
 
-  def reset(): Unit = sb = new StringBuilder
-
   trait Wrap {
     def prefix: Unit = ()
     def suffix: Unit = ()

--- a/scalafix/input/src/main/scala/rsc/tests/ExplicitSynthetics.scala
+++ b/scalafix/input/src/main/scala/rsc/tests/ExplicitSynthetics.scala
@@ -1,0 +1,52 @@
+/*
+rules = "scala:scalafix.internal.rule.ExplicitSynthetics"
+ */
+package rsc.tests
+
+class ExplicitSynthetics_Test {
+
+  val a = List(1, 2, 3)
+
+  List(1).map(_ + 2)
+  Array.empty[Int].headOption
+  "fooo".stripPrefix("o")
+
+  val Name = "name:(.*)".r
+  val x #:: xs = Stream(1, 2)
+  val Name(name) = "name:foo"
+  1 #:: 2 #:: Stream.empty
+
+  val lst = 1 #:: 2 #:: Stream.empty
+  lst + "foo"
+
+  for (x <- 1 to 10; y <- 0 until 10) println(x -> x)
+  for (i <- 1 to 10; j <- 0 until 10) yield (i, j)
+  for (i <- 1 to 10; j <- 0 until 10 if i % 2 == 0) yield (i, j)
+
+  object s {
+    def apply() = 2
+    s()
+    s.apply()
+    case class Bar()
+    Bar()
+    null.asInstanceOf[Int => Int](2)
+  }
+
+  class J[T: Manifest] { val arr = Array.empty[T] }
+
+  class F
+  implicit val ordering: Ordering[F] = ???
+  val f: Ordered[F] = new F
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  for {
+    a <- scala.concurrent.Future.successful(1)
+    b <- scala.concurrent.Future.successful(2)
+  } println(a)
+  for {
+    a <- scala.concurrent.Future.successful(1)
+    b <- scala.concurrent.Future.successful(2)
+    if a < b
+  } yield a
+
+}

--- a/scalafix/output/src/main/scala/rsc/tests/ExplicitSynthetics.scala
+++ b/scalafix/output/src/main/scala/rsc/tests/ExplicitSynthetics.scala
@@ -17,8 +17,8 @@ class ExplicitSynthetics_Test {
   _root_.scala.Predef.any2stringadd[_root_.scala.collection.immutable.Stream[_root_.scala.Int]](lst) + "foo"
 
   (1 to 10).foreach[_root_.scala.Unit]({x => (0 until 10).foreach[_root_.scala.Unit]({y => println(x -> x)})})
-  for (i <- 1 to 10; j <- 0 until 10) yield (i, j)
-  for (i <- 1 to 10; j <- 0 until 10 if i % 2 == 0) yield (i, j)
+  (1 to 10).flatMap[_root_.scala.Tuple2[_root_.scala.Int, _root_.scala.Int], _root_.scala.collection.immutable.IndexedSeq[_root_.scala.Tuple2[_root_.scala.Int, _root_.scala.Int]]]({i => (0 until 10).map[_root_.scala.Tuple2[_root_.scala.Int, _root_.scala.Int], _root_.scala.collection.immutable.IndexedSeq[_root_.scala.Tuple2[_root_.scala.Int, _root_.scala.Int]]]({j => (i, j)})(_root_.scala.collection.immutable.IndexedSeq.canBuildFrom[_root_.scala.Tuple2[_root_.scala.Int, _root_.scala.Int]])})(_root_.scala.collection.immutable.IndexedSeq.canBuildFrom[_root_.scala.Tuple2[_root_.scala.Int, _root_.scala.Int]])
+  (1 to 10).flatMap[_root_.scala.Tuple2[_root_.scala.Int, _root_.scala.Int], _root_.scala.collection.immutable.IndexedSeq[_root_.scala.Tuple2[_root_.scala.Int, _root_.scala.Int]]]({i => (0 until 10).withFilter({j => i % 2 == 0}).map[_root_.scala.Tuple2[_root_.scala.Int, _root_.scala.Int], _root_.scala.collection.immutable.IndexedSeq[_root_.scala.Tuple2[_root_.scala.Int, _root_.scala.Int]]]({j => (i, j)})(_root_.scala.collection.immutable.IndexedSeq.canBuildFrom[_root_.scala.Tuple2[_root_.scala.Int, _root_.scala.Int]])})(_root_.scala.collection.immutable.IndexedSeq.canBuildFrom[_root_.scala.Tuple2[_root_.scala.Int, _root_.scala.Int]])
 
   object s {
     def apply() = 2
@@ -29,7 +29,7 @@ class ExplicitSynthetics_Test {
     null.asInstanceOf[Int => Int].apply(2)
   }
 
-  class J[T: Manifest] { val arr = Array.empty[T] }
+  class J[T: Manifest] { val arr = Array.empty[T](J.this.evidence$1) }
 
   class F
   implicit val ordering: Ordering[F] = ???

--- a/scalafix/output/src/main/scala/rsc/tests/ExplicitSynthetics.scala
+++ b/scalafix/output/src/main/scala/rsc/tests/ExplicitSynthetics.scala
@@ -1,0 +1,42 @@
+package rsc.tests
+
+class ExplicitSynthetics_Test {
+
+  val a = List.apply[_root_.scala.Int](1, 2, 3)
+
+  List(1).map(_ + 2)(_root_.scala.collection.immutable.List.canBuildFrom[_root_.scala.Int])
+  Array.empty[Int](??? : _root_.scala.reflect.ClassTag[_root_.scala.Int]).headOption
+  _root_.scala.Predef.augmentString("fooo").stripPrefix("o")
+
+  val Name = _root_.scala.Predef.augmentString("name:(.*)").r
+  val x #:: xs = Stream.apply[_root_.scala.Int](1, 2)
+  val Name(name) = "name:foo"
+  1 #:: _root_.scala.collection.immutable.Stream.consWrapper[_root_.scala.Int](2 #:: Stream.empty)
+
+  val lst = 1 #:: _root_.scala.collection.immutable.Stream.consWrapper[_root_.scala.Int](2 #:: Stream.empty)
+  _root_.scala.Predef.any2stringadd[_root_.scala.collection.immutable.Stream[_root_.scala.Int]](lst) + "foo"
+
+  (1 to 10).foreach[_root_.scala.Unit]({x => (0 until 10).foreach[_root_.scala.Unit]({y => println(x -> x)})})
+  for (i <- 1 to 10; j <- 0 until 10) yield (i, j)
+  for (i <- 1 to 10; j <- 0 until 10 if i % 2 == 0) yield (i, j)
+
+  object s {
+    def apply() = 2
+    s.apply()
+    s.apply()
+    case class Bar()
+    Bar.apply()
+    null.asInstanceOf[Int => Int].apply(2)
+  }
+
+  class J[T: Manifest] { val arr = Array.empty[T] }
+
+  class F
+  implicit val ordering: Ordering[F] = ???
+  val f: Ordered[F] = _root_.scala.math.Ordered.orderingToOrdered[ExplicitSynthetics_Test.this.F](new F)(ExplicitSynthetics_Test.this.ordering)
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  scala.concurrent.Future.successful(1).foreach[_root_.scala.Unit]({a => scala.concurrent.Future.successful(2).foreach[_root_.scala.Unit]({b => println(a)})(_root_.scala.concurrent.ExecutionContext.Implicits.global)})(_root_.scala.concurrent.ExecutionContext.Implicits.global)
+  scala.concurrent.Future.successful(1).flatMap[_root_.scala.Int]({a => scala.concurrent.Future.successful(2).withFilter({b => a < b})(_root_.scala.concurrent.ExecutionContext.Implicits.global).map[_root_.scala.Int]({b => a})(_root_.scala.concurrent.ExecutionContext.Implicits.global)})(_root_.scala.concurrent.ExecutionContext.Implicits.global)
+
+}

--- a/scalafix/rules/src/main/scala/scalafix/internal/rule/ExplicitSynthetics.scala
+++ b/scalafix/rules/src/main/scala/scalafix/internal/rule/ExplicitSynthetics.scala
@@ -12,7 +12,7 @@ import scalafix.syntax._
 import scalafix.v0._
 
 case class ExplicitSynthetics(index: SemanticdbIndex)
-  extends SemanticRule(index, "ExplicitSynthetics") {
+    extends SemanticRule(index, "ExplicitSynthetics") {
 
   implicit class PositionOps(pos: Position) {
     def toRange: s.Range = s.Range(
@@ -82,7 +82,8 @@ case class ExplicitSynthetics(index: SemanticdbIndex)
     def apply(): Patch = {
       var p = Patch.empty
       rewriteTargets.foreach { target =>
-        val treePrinter = new SyntheticTreePrinter(target.env, ctx.input, doc, treePositions)
+        val treePrinter =
+          new SyntheticTreePrinter(target.env, ctx.input, doc, treePositions)
         treePrinter.pprint(target.syntheticTree)
         p += ctx.replaceTree(target.sourceTree, treePrinter.toString)
       }

--- a/scalafix/rules/src/main/scala/scalafix/internal/rule/ExplicitSynthetics.scala
+++ b/scalafix/rules/src/main/scala/scalafix/internal/rule/ExplicitSynthetics.scala
@@ -1,0 +1,163 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+// NOTE: This file has been partially copy/pasted from twitter/rsc.
+package scalafix.internal.rule
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+import java.nio.charset.StandardCharsets.UTF_8
+import scala.collection.mutable
+import scala.meta.internal.{semanticdb => s}
+import scala.meta.internal.semanticdb.Scala._
+import scala.meta.internal.semanticdb.Scala.{Descriptor => d}
+import scala.meta.internal.semanticdb.SymbolInformation.{Kind => k}
+import scala.meta.internal.semanticdb.SymbolInformation.{Property => p}
+import scala.meta._
+import scalafix.internal.rule.semantics._
+import scalafix.internal.rule.pretty._
+import scalafix.internal.patch.DocSemanticdbIndex
+import scalafix.syntax._
+import scalafix.v0._
+
+case class ExplicitSynthetics(index: SemanticdbIndex)
+  extends SemanticRule(index, "ExplicitSynthetics") {
+
+  implicit class PositionOps(pos: Position) {
+    def toRange: s.Range = s.Range(
+      startLine = pos.startLine,
+      endLine = pos.endLine,
+      startCharacter = pos.startColumn,
+      endCharacter = pos.endColumn
+    )
+  }
+
+  override def fix(ctx: RuleCtx): Patch = new SyntheticsRuleImpl(ctx)()
+
+  class SyntheticsRuleImpl(ctx: RuleCtx) {
+
+    val doc = index.asInstanceOf[DocSemanticdbIndex].doc.sdoc
+    val synthetics = doc.synthetics.map(synth => synth.range.get -> synth).toMap
+    val syntheticRanges = synthetics.keySet
+
+    case class RewriteTarget(env: Env, sourceTree: Tree, syntheticTree: s.Tree)
+
+    val rewriteTargets: List[RewriteTarget] = {
+      val buf = List.newBuilder[RewriteTarget]
+      def loop(env: Env, tree: Tree): Unit = tree match {
+        case Source(stats) =>
+          stats.foreach(loop(env, _))
+        case Pkg(_, stats) =>
+          stats.foreach(loop(env, _))
+        case Pkg.Object(_, name, templ) =>
+          loop(TemplateScope(name.symbol.get.syntax) :: env, templ)
+        case Defn.Class(_, name, _, _, templ) =>
+          loop(TemplateScope(name.symbol.get.syntax) :: env, templ)
+        case Defn.Trait(_, name, _, _, templ) =>
+          loop(TemplateScope(name.symbol.get.syntax) :: env, templ)
+        case Defn.Object(_, name, templ) =>
+          loop(TemplateScope(name.symbol.get.syntax) :: env, templ)
+        case Template(early, _, _, stats) =>
+          (early ++ stats).foreach(loop(env, _))
+        case Defn.Val(_, _, None, body) =>
+          loop(env, body)
+        case Defn.Var(_, _, None, Some(body)) =>
+          loop(env, body)
+        case Defn.Def(_, name, _, _, None, body) =>
+          loop(env, body)
+        case Term.Block(stats) =>
+          stats.foreach(loop(env, _))
+        case _ if synthetics.contains(tree.pos.toRange) =>
+          buf += RewriteTarget(env, tree, synthetics(tree.pos.toRange).tree)
+        case _ =>
+          tree.children.foreach { child =>
+            loop(env, child)
+          }
+      }
+      loop(Env(Nil), ctx.tree)
+      buf.result
+    }
+
+    val treePositions: Map[s.Range, Tree] = {
+      val pos = Map.newBuilder[s.Range, Tree]
+      def loop(tree: Tree): Unit = {
+        pos += tree.pos.toRange -> tree
+        tree.children.foreach(loop)
+      }
+      loop(ctx.tree)
+      pos.result
+    }
+
+    def pprint(env: Env, tree: s.Tree): String = tree match {
+      case s.OriginalTree(range) =>
+        val r = range.get
+        val lines = ctx.input.text.split('\n').toSeq
+        val linesSubseq = lines.slice(r.startLine, r.endLine + 1)
+        if (r.startLine == r.endLine) {
+          linesSubseq.head.substring(r.startCharacter, r.endCharacter)
+        } else {
+          val mid = linesSubseq.tail.init
+          val newFirstLine = linesSubseq.head.substring(r.startCharacter)
+          val newEndLine = linesSubseq.last.substring(0, r.endCharacter)
+          (newFirstLine +: mid :+ newEndLine).mkString("\n")
+        }
+      case s.ApplyTree(fn, args) =>
+        pprint(env, fn) + args.map(t => pprint(env, t)).mkString("(", ", ", ")")
+      case s.TypeApplyTree(fn, targs) =>
+        val types = targs.map { t =>
+          val typePrinter = new TypePrinter(env)
+          typePrinter.pprint(t)
+          typePrinter.toString
+        }
+        pprint(env, fn) + types.mkString("[", ", ", "]")
+      case s.SelectTree(qual, id) =>
+        pprint(env, qual) + "." + id.get.sym.desc.name
+      case s.IdTree(sym) => pprintFqn(env, sym)
+      case s.FunctionTree(params, term) =>
+        val paramsString = params match {
+          case Seq() => ""
+          case Seq(id) =>  pprintName(env, id.sym) + " => "
+          case _ => params.map(id => pprintName(env, id.sym)).mkString("(", ", ", ") => ")
+        }
+        "{" + paramsString + pprint(env, term) + "}"
+      case s.MacroExpansionTree(tpe) =>
+        val typePrinter = new TypePrinter(env)
+        typePrinter.pprint(tpe)
+        s"??? : $typePrinter"
+    }
+
+    def pprintName(env: Env, sym: String): String = {
+      val typePrinter = new TypePrinter(env)
+      doc.symbols.foreach(typePrinter.addInfo)
+      typePrinter.pprint(sym)
+      typePrinter.toString
+    }
+
+    def pprintFqn(env: Env, sym: String): String = {
+      val prefixFqn = {
+        val owner = sym.owner
+        if (owner == Symbols.None) "" else {
+          val ownerFqn = pprintFqn(env, sym.owner)
+          owner.desc match {
+            case _: d.Package => ownerFqn + "."
+            case _: d.Term => ownerFqn + "."
+            case desc: d.Type =>
+              if (env.lookupThis(desc.name) == owner) {
+                pprintName(env, owner) + ".this."
+              } else ownerFqn + "."
+          }
+        }
+      }
+      prefixFqn + pprintName(env, sym)
+    }
+
+    def apply(): Patch = {
+      var p = Patch.empty
+      rewriteTargets.foreach { target =>
+        val newTree = pprint(target.env, target.syntheticTree)
+        p += ctx.replaceTree(target.sourceTree, newTree)
+      }
+      p
+    }
+
+  }
+
+}

--- a/scalafix/rules/src/main/scala/scalafix/internal/rule/pretty/SyntheticTreePrinter.scala
+++ b/scalafix/rules/src/main/scala/scalafix/internal/rule/pretty/SyntheticTreePrinter.scala
@@ -1,0 +1,116 @@
+package scalafix.internal.rule.pretty
+
+import rsc.pretty.Printer
+import scala.meta._
+import rsc.{syntax => r}
+import rsc.pretty._
+import scala.meta.inputs._
+import scala.meta.internal.{semanticdb => s}
+import scala.meta.internal.semanticdb.Scala.{Descriptor => d}
+import scala.meta.internal.semanticdb.Scala._
+import scalafix.internal.rule.semantics.Env
+
+class SyntheticTreePrinter(env: Env, input: Input, doc: s.TextDocument, treePositions: Map[s.Range, Tree]) extends Printer {
+
+  implicit class ScalametaTermOps(term: Term) {
+    def rscWeight: Weight = term match {
+      case term: Term.Name => r.TermId(null).weight
+      case term: Term.Apply =>
+        r.TermApply(null, null).weight
+      case term: Term.ApplyInfix =>
+        r.TermApplyInfix(r.TermId("$synth"), term.op.toRscId, List(), List()).weight
+      case term: Term.ApplyType =>
+        r.TermApplyType(null, null).weight
+      case term: Lit =>
+        r.TermLit(null).weight
+      case term: Term.Select =>
+        r.TermSelect(null, null).weight
+    }
+    def toRscId: r.TermId = term match {
+      case Term.Name(value) => r.TermId(value)
+    }
+  }
+
+  def pprint(tree: s.Tree): Unit = tree match {
+    case s.OriginalTree(range) =>
+      val r = range.get
+      val lines = input.text.split('\n').toSeq
+      val linesSubseq = lines.slice(r.startLine, r.endLine + 1)
+      if (r.startLine == r.endLine) {
+        str(linesSubseq.head.substring(r.startCharacter, r.endCharacter))
+      } else {
+        val mid = linesSubseq.tail.init
+        val newFirstLine = linesSubseq.head.substring(r.startCharacter)
+        val newEndLine = linesSubseq.last.substring(0, r.endCharacter)
+        str((newFirstLine +: mid :+ newEndLine).mkString("\n"))
+      }
+    case s.ApplyTree(fn, args) =>
+      pprint(fn)
+      rep("(", args, ", ", ")")(t => pprint(t))
+    case s.TypeApplyTree(fn, targs) =>
+      pprint(fn)
+      rep("[", targs, ", ", "]") {t =>
+        val typePrinter = new TypePrinter(env)
+        typePrinter.pprint(t)
+        str(typePrinter.toString)
+      }
+    case s.SelectTree(qual, id) =>
+      val needsParens = qual match {
+        case s.OriginalTree(range) =>
+          val rscWeight = treePositions(range.get).asInstanceOf[Term].rscWeight
+          rscWeight.value < SimpleExpr1.value
+        case _ => false
+      }
+      if (needsParens) str("(")
+      pprint(qual)
+      if (needsParens) str(")")
+      str(".")
+      str(id.get.sym.desc.name)
+    case s.IdTree(sym) => pprintFqn(env, sym)
+    case s.FunctionTree(params, term) =>
+      str("{")
+      params match {
+        case Seq() => ()
+        case Seq(id) =>
+          pprintName(env, id.sym)
+          str(" => ")
+        case _ =>
+          rep("(", params, ", ", ") => ")(id => pprintName(env, id.sym))
+      }
+      pprint(term)
+      str("}")
+    case s.MacroExpansionTree(tpe) =>
+      val typePrinter = new TypePrinter(env)
+      typePrinter.pprint(tpe)
+      str("??? : ")
+      str(typePrinter.toString)
+  }
+
+  def pprintName(env: Env, sym: String): Unit = {
+    val typePrinter = new TypePrinter(env)
+    doc.symbols.foreach(typePrinter.addInfo)
+    typePrinter.pprint(sym)
+    str(typePrinter.toString)
+  }
+
+  def pprintFqn(env: Env, sym: String): Unit = {
+    val owner = sym.owner
+    if (owner != Symbols.None) {
+      owner.desc match {
+        case _: d.Package =>
+          pprintFqn(env, sym.owner)
+          str(".")
+        case _: d.Term =>
+          pprintFqn(env, sym.owner)
+          str(".")
+        case desc: d.Type =>
+          if (env.lookupThis(desc.name) == owner) {
+            pprintName(env, owner)
+            str(".this.")
+          } else str(".")
+      }
+    }
+    pprintName(env, sym)
+  }
+
+}

--- a/scalafix/rules/src/main/scala/scalafix/internal/rule/pretty/SyntheticTreePrinter.scala
+++ b/scalafix/rules/src/main/scala/scalafix/internal/rule/pretty/SyntheticTreePrinter.scala
@@ -10,7 +10,12 @@ import scala.meta.internal.semanticdb.Scala.{Descriptor => d}
 import scala.meta.internal.semanticdb.Scala._
 import scalafix.internal.rule.semantics.Env
 
-class SyntheticTreePrinter(env: Env, input: Input, doc: s.TextDocument, treePositions: Map[s.Range, Tree]) extends Printer {
+class SyntheticTreePrinter(
+    env: Env,
+    input: Input,
+    doc: s.TextDocument,
+    treePositions: Map[s.Range, Tree])
+    extends Printer {
 
   implicit class ScalametaTermOps(term: Term) {
     def rscWeight: Weight = term match {
@@ -18,7 +23,8 @@ class SyntheticTreePrinter(env: Env, input: Input, doc: s.TextDocument, treePosi
       case term: Term.Apply =>
         r.TermApply(null, null).weight
       case term: Term.ApplyInfix =>
-        r.TermApplyInfix(r.TermId("$synth"), term.op.toRscId, List(), List()).weight
+        r.TermApplyInfix(r.TermId("$synth"), term.op.toRscId, List(), List())
+          .weight
       case term: Term.ApplyType =>
         r.TermApplyType(null, null).weight
       case term: Lit =>
@@ -49,7 +55,7 @@ class SyntheticTreePrinter(env: Env, input: Input, doc: s.TextDocument, treePosi
       rep("(", args, ", ", ")")(t => pprint(t))
     case s.TypeApplyTree(fn, targs) =>
       pprint(fn)
-      rep("[", targs, ", ", "]") {t =>
+      rep("[", targs, ", ", "]") { t =>
         val typePrinter = new TypePrinter(env)
         typePrinter.pprint(t)
         str(typePrinter.toString)

--- a/scalafix/rules/src/main/scala/scalafix/internal/rule/pretty/TypePrinter.scala
+++ b/scalafix/rules/src/main/scala/scalafix/internal/rule/pretty/TypePrinter.scala
@@ -110,7 +110,7 @@ class TypePrinter(env: Env) extends Printer {
     normal(tpe)
   }
 
-  private def pprint(sym: String): Unit = {
+  def pprint(sym: String): Unit = {
     val printableName = {
       val sourceName = notes.get(sym).map(_.name)
       sourceName match {
@@ -188,6 +188,10 @@ class TypePrinter(env: Env) extends Printer {
       case tpe =>
         pprint(tpe)
     }
+  }
+
+  def addInfo(info: s.SymbolInformation): Unit = {
+    notes.append(info)
   }
 
   private object notes {

--- a/scalafix/rules/src/main/scala/scalafix/internal/rule/pretty/TypePrinter.scala
+++ b/scalafix/rules/src/main/scala/scalafix/internal/rule/pretty/TypePrinter.scala
@@ -113,7 +113,6 @@ class TypePrinter(env: Env) extends Printer {
   def pprint(sym: String): Unit = {
     val printableName = {
       val sourceName = notes.get(sym).map(_.name)
-      println(sym, notes.get(sym))
       sourceName match {
         case Some(name) =>
           if (name == "") {

--- a/scalafix/rules/src/main/scala/scalafix/internal/rule/pretty/TypePrinter.scala
+++ b/scalafix/rules/src/main/scala/scalafix/internal/rule/pretty/TypePrinter.scala
@@ -113,6 +113,7 @@ class TypePrinter(env: Env) extends Printer {
   def pprint(sym: String): Unit = {
     val printableName = {
       val sourceName = notes.get(sym).map(_.name)
+      println(sym, notes.get(sym))
       sourceName match {
         case Some(name) =>
           if (name == "") {


### PR DESCRIPTION
This PR adds a scalafix rule that expands synthetics like implicit views and parameters or type applications on methods. I have only tested it on [ExplicitSynthetics.scala](https://github.com/twitter/rsc/compare/master...maxov:explicit-synthetics?expand=1#diff-2f112dcd6938be06aeb6f62385040c01), which was copied from scalameta. I'm certain that it will not yet work for larger codebases, but this is a good start.