### PR TITLE
Assorted improvements that make parser and prettyprinter work on a case study project

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -13,6 +13,7 @@ project.excludeFilters = [
   "scalafix/output/.*",
   ".*/target/.*",
   ".*/sandbox/.*",
+  "rsc/rsc/src/main/scala/rsc/scan/Xml.scala",
   "scala/meta/scalasig/highlevel/Entities.scala",
   "scala/meta/scalasig/lowlevel/Entities.scala",
 ]

--- a/build.sbt
+++ b/build.sbt
@@ -99,6 +99,7 @@ lazy val rsc = project
     commonSettings,
     publishableSettings,
     libraryDependencies += "org.scalameta" %% "semanticdb" % V.scalameta,
+    libraryDependencies += "com.lihaoyi" %% "fastparse" % "1.0.0",
     mainClass := Some("rsc.cli.Main")
   )
 

--- a/check/src/main/scala/rsc/checkbase/Job.scala
+++ b/check/src/main/scala/rsc/checkbase/Job.scala
@@ -5,7 +5,7 @@ package rsc.checkbase
 case class Job[T](xs: List[T], settings: SettingsBase) {
   def foreach(fn: T => Unit): Unit = {
     val startStamp = timestamp()
-    var lastStamp = 0
+    var lastStamp = 0.0
     var n = xs.length
     var i = 0
     val it = xs.iterator
@@ -16,6 +16,7 @@ case class Job[T](xs: List[T], settings: SettingsBase) {
       if ((i % 100) == 0) {
         val currentStamp = timestamp()
         if (currentStamp - lastStamp > 3.0) {
+          lastStamp = currentStamp
           val elapsedSeconds = currentStamp - startStamp
           val remainingSeconds = elapsedSeconds * (n - i) / i
           val remaining = "%.2f".format(remainingSeconds) + "s"
@@ -23,6 +24,9 @@ case class Job[T](xs: List[T], settings: SettingsBase) {
         }
       }
     }
+    val elapsedSeconds = timestamp() - startStamp
+    val elapsed = "%.2f".format(elapsedSeconds) + "s"
+    println(s"Job finished in $elapsed")
   }
 
   private def timestamp(): Double = {

--- a/check/src/main/scala/rsc/checkbase/Job.scala
+++ b/check/src/main/scala/rsc/checkbase/Job.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.checkbase
+
+case class Job[T](xs: List[T], settings: SettingsBase) {
+  def foreach(fn: T => Unit): Unit = {
+    val startStamp = timestamp()
+    var lastStamp = 0
+    var n = xs.length
+    var i = 0
+    val it = xs.iterator
+    while (it.hasNext) {
+      val item = it.next()
+      fn(item)
+      i += 1
+      if ((i % 100) == 0) {
+        val currentStamp = timestamp()
+        if (currentStamp - lastStamp > 3.0) {
+          val elapsedSeconds = currentStamp - startStamp
+          val remainingSeconds = elapsedSeconds * (n - i) / i
+          val remaining = "%.2f".format(remainingSeconds) + "s"
+          println(s"($i / $n) $remaining remaining")
+        }
+      }
+    }
+  }
+
+  private def timestamp(): Double = {
+    1.0 * System.nanoTime() / 1000000000
+  }
+}

--- a/check/src/main/scala/rsc/checkbase/Job.scala
+++ b/check/src/main/scala/rsc/checkbase/Job.scala
@@ -13,7 +13,7 @@ case class Job[T](xs: List[T], settings: SettingsBase) {
       val item = it.next()
       fn(item)
       i += 1
-      if ((i % 100) == 0) {
+      if (!settings.quiet && (i % 100) == 0) {
         val currentStamp = timestamp()
         if (currentStamp - lastStamp > 3.0) {
           lastStamp = currentStamp
@@ -24,9 +24,11 @@ case class Job[T](xs: List[T], settings: SettingsBase) {
         }
       }
     }
-    val elapsedSeconds = timestamp() - startStamp
-    val elapsed = "%.2f".format(elapsedSeconds) + "s"
-    println(s"Job finished in $elapsed")
+    if (!settings.quiet) {
+      val elapsedSeconds = timestamp() - startStamp
+      val elapsed = "%.2f".format(elapsedSeconds) + "s"
+      println(s"Job finished in $elapsed")
+    }
   }
 
   private def timestamp(): Double = {

--- a/check/src/main/scala/rsc/checkbase/MainBase.scala
+++ b/check/src/main/scala/rsc/checkbase/MainBase.scala
@@ -8,7 +8,10 @@ import rsc.pretty._
 import scala.collection.mutable
 import scala.util._
 
-trait MainBase[S <: SettingsBase, I, N, R] extends DiffUtil with NscUtil with ToolUtil {
+trait MainBase[S <: SettingsBase, I, N, R]
+    extends DiffUtil
+    with NscUtil
+    with ToolUtil {
   def main(args: Array[String]): Unit = {
     val expandedArgs = {
       args match {

--- a/check/src/main/scala/rsc/checkbase/MainBase.scala
+++ b/check/src/main/scala/rsc/checkbase/MainBase.scala
@@ -8,7 +8,7 @@ import rsc.pretty._
 import scala.collection.mutable
 import scala.util._
 
-trait MainBase[S, I, N, R] extends DiffUtil with NscUtil with ToolUtil {
+trait MainBase[S <: SettingsBase, I, N, R] extends DiffUtil with NscUtil with ToolUtil {
   def main(args: Array[String]): Unit = {
     val expandedArgs = {
       args match {
@@ -38,7 +38,8 @@ trait MainBase[S, I, N, R] extends DiffUtil with NscUtil with ToolUtil {
       allProblems += problem
     }
 
-    inputs(settings).foreach { input =>
+    val job = Job(inputs(settings), settings)
+    job.foreach { input =>
       (nscResult(input), rscResult(input)) match {
         case (Left(nscFailures), _) =>
           val nscProblems = nscFailures.map(FailedNscProblem)
@@ -54,7 +55,7 @@ trait MainBase[S, I, N, R] extends DiffUtil with NscUtil with ToolUtil {
           }
           rscProblems.foreach(report)
         case (Right(nscResult), Right(rscResult)) =>
-          val checker = this.checker(nscResult, rscResult)
+          val checker = this.checker(settings, nscResult, rscResult)
           checker.check()
           checker.problems.foreach(report)
       }
@@ -74,5 +75,5 @@ trait MainBase[S, I, N, R] extends DiffUtil with NscUtil with ToolUtil {
   def inputs(settings: S): List[I]
   def nscResult(input: I): Either[List[String], N]
   def rscResult(input: I): Either[List[String], R]
-  def checker(nscResult: N, rscResult: R): CheckerBase
+  def checker(settings: S, nscResult: N, rscResult: R): CheckerBase
 }

--- a/check/src/main/scala/rsc/checkbase/MainBase.scala
+++ b/check/src/main/scala/rsc/checkbase/MainBase.scala
@@ -14,13 +14,14 @@ trait MainBase[S <: SettingsBase, I, N, R]
     with ToolUtil {
   def main(args: Array[String]): Unit = {
     val expandedArgs = {
-      args match {
-        case Array(arg) if arg.startsWith("@") =>
+      args.toList.flatMap { arg =>
+        if (arg.startsWith("@")) {
           val argPath = Paths.get(arg.substring(1))
           val argText = new String(Files.readAllBytes(argPath), UTF_8)
           argText.split(EOL).map(_.trim).filter(_.nonEmpty).toList
-        case other =>
-          other.toList
+        } else {
+          List(arg)
+        }
       }
     }
     settings(expandedArgs) match {

--- a/check/src/main/scala/rsc/checkbase/SettingsBase.scala
+++ b/check/src/main/scala/rsc/checkbase/SettingsBase.scala
@@ -1,0 +1,7 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.checkbase
+
+trait SettingsBase {
+  def quiet: Boolean
+}

--- a/check/src/main/scala/rsc/checkbase/SimpleBase.scala
+++ b/check/src/main/scala/rsc/checkbase/SimpleBase.scala
@@ -2,6 +2,6 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.checkbase
 
-trait SimpleBase[S, N, R] extends MainBase[S, S, N, R] {
+trait SimpleBase[S <: SettingsBase, N, R] extends MainBase[S, S, N, R] {
   def inputs(settings: S) = List(settings)
 }

--- a/check/src/main/scala/rsc/checkmjar/Checker.scala
+++ b/check/src/main/scala/rsc/checkmjar/Checker.scala
@@ -11,7 +11,8 @@ import scala.meta.internal.scalasig._
 import scala.meta.scalasig._
 import scala.meta.scalasig.highlevel._
 
-class Checker(settings: Settings, nscResult: Path, rscResult: Path) extends CheckerBase {
+class Checker(settings: Settings, nscResult: Path, rscResult: Path)
+    extends CheckerBase {
   def check(): Unit = {
     val nscMaps = load(nscResult, FailedNscProblem.apply)
     val rscMaps = load(rscResult, FailedRscProblem.apply)

--- a/check/src/main/scala/rsc/checkmjar/Checker.scala
+++ b/check/src/main/scala/rsc/checkmjar/Checker.scala
@@ -11,12 +11,13 @@ import scala.meta.internal.scalasig._
 import scala.meta.scalasig._
 import scala.meta.scalasig.highlevel._
 
-class Checker(nscResult: Path, rscResult: Path) extends CheckerBase {
+class Checker(settings: Settings, nscResult: Path, rscResult: Path) extends CheckerBase {
   def check(): Unit = {
     val nscMaps = load(nscResult, FailedNscProblem.apply)
     val rscMaps = load(rscResult, FailedRscProblem.apply)
     val names = (nscMaps.keys ++ rscMaps.keys).toList.sorted
-    names.foreach { name =>
+    val job = Job(names, settings)
+    job.foreach { name =>
       val nscMap = nscMaps.get(name)
       val rscMap = rscMaps.get(name)
       (nscMap, rscMap) match {

--- a/check/src/main/scala/rsc/checkmjar/Main.scala
+++ b/check/src/main/scala/rsc/checkmjar/Main.scala
@@ -19,7 +19,7 @@ object Main extends SimpleBase[Settings, Path, Path] {
     semanticdbResult.right.flatMap(path => mjar(List(path)))
   }
 
-  def checker(nscResult: Path, rscResult: Path) = {
-    new Checker(nscResult, rscResult)
+  def checker(settings: Settings, nscResult: Path, rscResult: Path) = {
+    new Checker(settings, nscResult, rscResult)
   }
 }

--- a/check/src/main/scala/rsc/checkmjar/Settings.scala
+++ b/check/src/main/scala/rsc/checkmjar/Settings.scala
@@ -6,7 +6,11 @@ import java.io.File.pathSeparator
 import java.nio.file._
 import rsc.checkbase._
 
-final case class Settings(cp: List[Path] = Nil, ins: List[Path] = Nil, quiet: Boolean = false) extends SettingsBase
+final case class Settings(
+    cp: List[Path] = Nil,
+    ins: List[Path] = Nil,
+    quiet: Boolean = false)
+    extends SettingsBase
 
 // FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {

--- a/check/src/main/scala/rsc/checkmjar/Settings.scala
+++ b/check/src/main/scala/rsc/checkmjar/Settings.scala
@@ -4,9 +4,11 @@ package rsc.checkmjar
 
 import java.io.File.pathSeparator
 import java.nio.file._
+import rsc.checkbase._
 
-final case class Settings(cp: List[Path] = Nil, ins: List[Path] = Nil)
+final case class Settings(cp: List[Path] = Nil, ins: List[Path] = Nil, quiet: Boolean = false) extends SettingsBase
 
+// FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {
   def parse(args: List[String]): Either[List[String], Settings] = {
     def loop(
@@ -19,6 +21,8 @@ object Settings {
         case ("-classpath" | "-cp") +: s_cp +: rest if allowOptions =>
           val cp = s_cp.split(pathSeparator).map(s => Paths.get(s)).toList
           loop(settings.copy(cp = settings.cp ++ cp), true, rest)
+        case "--quiet" +: rest if allowOptions =>
+          loop(settings.copy(quiet = true), true, rest)
         case flag +: rest if allowOptions && flag.startsWith("-") =>
           Left(List(s"unknown flag $flag"))
         case in +: rest =>

--- a/check/src/main/scala/rsc/checkmjar/Settings.scala
+++ b/check/src/main/scala/rsc/checkmjar/Settings.scala
@@ -18,7 +18,7 @@ object Settings {
       args match {
         case "--" +: rest =>
           loop(settings, false, rest)
-        case ("-classpath" | "-cp") +: s_cp +: rest if allowOptions =>
+        case "--classpath" +: s_cp +: rest if allowOptions =>
           val cp = s_cp.split(pathSeparator).map(s => Paths.get(s)).toList
           loop(settings.copy(cp = settings.cp ++ cp), true, rest)
         case "--quiet" +: rest if allowOptions =>

--- a/check/src/main/scala/rsc/checkoutline/Checker.scala
+++ b/check/src/main/scala/rsc/checkoutline/Checker.scala
@@ -13,14 +13,15 @@ import scala.meta.internal.semanticdb.SymbolInformation.{Kind => k}
 import scala.meta.internal.semanticdb.SymbolInformation.Property
 import scala.meta.internal.semanticdb.SymbolInformation.{Property => p}
 
-class Checker(nscResult: Path, rscResult: Path) extends CheckerBase {
+class Checker(settings: Settings, nscResult: Path, rscResult: Path) extends CheckerBase {
   def check(): Unit = {
     val nscMap = load(nscResult)
     val rscMap = load(rscResult)
     val nscMap1 = highlevelPatch(nscMap)
     val rscMap1 = highlevelPatch(rscMap)
     val syms = (nscMap1.keys ++ rscMap1.keys).toList.sorted
-    syms.foreach { sym =>
+    val job = Job(syms, settings)
+    job.foreach { sym =>
       val nscInfo = nscMap1.get(sym)
       val rscInfo = rscMap1.get(sym)
       (nscInfo, rscInfo) match {

--- a/check/src/main/scala/rsc/checkoutline/Checker.scala
+++ b/check/src/main/scala/rsc/checkoutline/Checker.scala
@@ -13,7 +13,8 @@ import scala.meta.internal.semanticdb.SymbolInformation.{Kind => k}
 import scala.meta.internal.semanticdb.SymbolInformation.Property
 import scala.meta.internal.semanticdb.SymbolInformation.{Property => p}
 
-class Checker(settings: Settings, nscResult: Path, rscResult: Path) extends CheckerBase {
+class Checker(settings: Settings, nscResult: Path, rscResult: Path)
+    extends CheckerBase {
   def check(): Unit = {
     val nscMap = load(nscResult)
     val rscMap = load(rscResult)

--- a/check/src/main/scala/rsc/checkoutline/Main.scala
+++ b/check/src/main/scala/rsc/checkoutline/Main.scala
@@ -20,7 +20,7 @@ object Main extends SimpleBase[Settings, Path, Path] {
     rsc(settings.cp, settings.ins)
   }
 
-  def checker(nscResult: Path, rscResult: Path) = {
-    new Checker(nscResult, rscResult)
+  def checker(settings: Settings, nscResult: Path, rscResult: Path) = {
+    new Checker(settings, nscResult, rscResult)
   }
 }

--- a/check/src/main/scala/rsc/checkoutline/Settings.scala
+++ b/check/src/main/scala/rsc/checkoutline/Settings.scala
@@ -6,7 +6,11 @@ import java.io.File.pathSeparator
 import java.nio.file._
 import rsc.checkbase._
 
-final case class Settings(cp: List[Path] = Nil, ins: List[Path] = Nil, quiet: Boolean = false) extends SettingsBase
+final case class Settings(
+    cp: List[Path] = Nil,
+    ins: List[Path] = Nil,
+    quiet: Boolean = false)
+    extends SettingsBase
 
 // FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {

--- a/check/src/main/scala/rsc/checkoutline/Settings.scala
+++ b/check/src/main/scala/rsc/checkoutline/Settings.scala
@@ -4,9 +4,11 @@ package rsc.checkoutline
 
 import java.io.File.pathSeparator
 import java.nio.file._
+import rsc.checkbase._
 
-final case class Settings(cp: List[Path] = Nil, ins: List[Path] = Nil)
+final case class Settings(cp: List[Path] = Nil, ins: List[Path] = Nil, quiet: Boolean = false) extends SettingsBase
 
+// FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {
   def parse(args: List[String]): Either[List[String], Settings] = {
     def loop(
@@ -19,6 +21,8 @@ object Settings {
         case ("-classpath" | "-cp") +: s_cp +: rest if allowOptions =>
           val cp = s_cp.split(pathSeparator).map(s => Paths.get(s)).toList
           loop(settings.copy(cp = settings.cp ++ cp), true, rest)
+        case "--quiet" +: rest if allowOptions =>
+          loop(settings.copy(quiet = true), true, rest)
         case flag +: rest if allowOptions && flag.startsWith("-") =>
           Left(List(s"unknown flag $flag"))
         case in +: rest =>

--- a/check/src/main/scala/rsc/checkoutline/Settings.scala
+++ b/check/src/main/scala/rsc/checkoutline/Settings.scala
@@ -18,7 +18,7 @@ object Settings {
       args match {
         case "--" +: rest =>
           loop(settings, false, rest)
-        case ("-classpath" | "-cp") +: s_cp +: rest if allowOptions =>
+        case "--classpath" +: s_cp +: rest if allowOptions =>
           val cp = s_cp.split(pathSeparator).map(s => Paths.get(s)).toList
           loop(settings.copy(cp = settings.cp ++ cp), true, rest)
         case "--quiet" +: rest if allowOptions =>

--- a/check/src/main/scala/rsc/checkparse/Checker.scala
+++ b/check/src/main/scala/rsc/checkparse/Checker.scala
@@ -8,7 +8,11 @@ import rsc.{syntax => r}
 import scala.tools.nsc.{Global => NscGlobal}
 import scala.util._
 
-class Checker(settings: Settings, g: NscGlobal, nscTree1: NscGlobal#Tree, rscTree1: r.Tree)
+class Checker(
+    settings: Settings,
+    g: NscGlobal,
+    nscTree1: NscGlobal#Tree,
+    rscTree1: r.Tree)
     extends CheckerBase
     with DiffUtil {
   def check(): Unit = {

--- a/check/src/main/scala/rsc/checkparse/Checker.scala
+++ b/check/src/main/scala/rsc/checkparse/Checker.scala
@@ -8,7 +8,7 @@ import rsc.{syntax => r}
 import scala.tools.nsc.{Global => NscGlobal}
 import scala.util._
 
-class Checker(g: NscGlobal, nscTree1: NscGlobal#Tree, rscTree1: r.Tree)
+class Checker(settings: Settings, g: NscGlobal, nscTree1: NscGlobal#Tree, rscTree1: r.Tree)
     extends CheckerBase
     with DiffUtil {
   def check(): Unit = {

--- a/check/src/main/scala/rsc/checkparse/Main.scala
+++ b/check/src/main/scala/rsc/checkparse/Main.scala
@@ -25,7 +25,10 @@ object Main extends MainBase[Settings, Path, NscGlobal#Tree, RscTree] {
     path.parseRsc()
   }
 
-  def checker(settings: Settings, nscResult: NscGlobal#Tree, rscResult: RscTree) = {
+  def checker(
+      settings: Settings,
+      nscResult: NscGlobal#Tree,
+      rscResult: RscTree) = {
     new Checker(settings, nscGlobal, nscResult, rscResult)
   }
 

--- a/check/src/main/scala/rsc/checkparse/Main.scala
+++ b/check/src/main/scala/rsc/checkparse/Main.scala
@@ -25,8 +25,8 @@ object Main extends MainBase[Settings, Path, NscGlobal#Tree, RscTree] {
     path.parseRsc()
   }
 
-  def checker(nscResult: NscGlobal#Tree, rscResult: RscTree) = {
-    new Checker(nscGlobal, nscResult, rscResult)
+  def checker(settings: Settings, nscResult: NscGlobal#Tree, rscResult: RscTree) = {
+    new Checker(settings, nscGlobal, nscResult, rscResult)
   }
 
   private lazy val nscGlobal: NscGlobal = {

--- a/check/src/main/scala/rsc/checkparse/Settings.scala
+++ b/check/src/main/scala/rsc/checkparse/Settings.scala
@@ -5,7 +5,8 @@ package rsc.checkparse
 import java.nio.file._
 import rsc.checkbase._
 
-final case class Settings(ins: List[Path] = Nil, quiet: Boolean = false) extends SettingsBase
+final case class Settings(ins: List[Path] = Nil, quiet: Boolean = false)
+    extends SettingsBase
 
 // FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {

--- a/check/src/main/scala/rsc/checkparse/Settings.scala
+++ b/check/src/main/scala/rsc/checkparse/Settings.scala
@@ -3,11 +3,31 @@
 package rsc.checkparse
 
 import java.nio.file._
+import rsc.checkbase._
 
-final case class Settings(ins: List[Path] = Nil)
+final case class Settings(ins: List[Path] = Nil, quiet: Boolean = false) extends SettingsBase
 
+// FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {
   def parse(args: List[String]): Either[List[String], Settings] = {
-    Right(Settings(args.map(s => Paths.get(s))))
+    def loop(
+        settings: Settings,
+        allowOptions: Boolean,
+        args: List[String]): Either[List[String], Settings] = {
+      args match {
+        case "--" +: rest =>
+          loop(settings, false, rest)
+        case "--quiet" +: rest if allowOptions =>
+          loop(settings.copy(quiet = true), true, rest)
+        case flag +: rest if allowOptions && flag.startsWith("-") =>
+          Left(List(s"unknown flag $flag"))
+        case in +: rest =>
+          val ins = List(Paths.get(in))
+          loop(settings.copy(ins = settings.ins ++ ins), allowOptions, rest)
+        case Nil =>
+          Right(settings)
+      }
+    }
+    loop(Settings(), true, args)
   }
 }

--- a/check/src/main/scala/rsc/checkparse/package.scala
+++ b/check/src/main/scala/rsc/checkparse/package.scala
@@ -50,6 +50,8 @@ package object checkparse extends NscUtil {
         val rscTree = {
           try rscParser.source()
           catch {
+            case ex: CrashException =>
+              throw ex
             case ex: Throwable =>
               val offset = rscParser.in.lastOffset
               val pos = RscPosition(rscInput, offset, offset)
@@ -72,11 +74,7 @@ package object checkparse extends NscUtil {
         else Right(rscTree)
       } catch {
         case ex: CrashException =>
-          val buf = new StringBuilder
-          buf ++= s"${ex.pos.input.path}:"
-          buf ++= s"${ex.pos.startLine + 1}: "
-          buf ++= ex.str
-          Left(List(buf.toString))
+          Left(List(ex.str))
         case ex: Throwable =>
           Left(List(s"crash when parsing $path:$EOL${ex.str}"))
       }

--- a/check/src/main/scala/rsc/diffmjar/Main.scala
+++ b/check/src/main/scala/rsc/diffmjar/Main.scala
@@ -4,7 +4,7 @@ package rsc.diffmjar
 
 import java.nio.file._
 import rsc.checkbase._
-import rsc.checkmjar.Checker
+import rsc.checkmjar
 
 object Main extends SimpleBase[Settings, Path, Path] {
   def settings(args: List[String]) = {
@@ -19,7 +19,8 @@ object Main extends SimpleBase[Settings, Path, Path] {
     Right(settings.rscMjar)
   }
 
-  def checker(nscResult: Path, rscResult: Path) = {
-    new Checker(nscResult, rscResult)
+  def checker(settings: Settings, nscResult: Path, rscResult: Path) = {
+    val checkerSettings = checkmjar.Settings(quiet = settings.quiet)
+    new checkmjar.Checker(checkerSettings, nscResult, rscResult)
   }
 }

--- a/check/src/main/scala/rsc/diffmjar/Settings.scala
+++ b/check/src/main/scala/rsc/diffmjar/Settings.scala
@@ -5,7 +5,8 @@ package rsc.diffmjar
 import java.nio.file._
 import rsc.checkbase._
 
-final case class Settings(nscMjar: Path, rscMjar: Path, quiet: Boolean) extends SettingsBase
+final case class Settings(nscMjar: Path, rscMjar: Path, quiet: Boolean)
+    extends SettingsBase
 
 // FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {

--- a/check/src/main/scala/rsc/diffmjar/Settings.scala
+++ b/check/src/main/scala/rsc/diffmjar/Settings.scala
@@ -3,18 +3,22 @@
 package rsc.diffmjar
 
 import java.nio.file._
+import rsc.checkbase._
 
-final case class Settings(nscMjar: Path, rscMjar: Path)
+final case class Settings(nscMjar: Path, rscMjar: Path, quiet: Boolean) extends SettingsBase
 
+// FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {
   def parse(args: List[String]): Either[List[String], Settings] = {
-    args match {
+    val (flags, rest) = args.partition(_.startsWith("--"))
+    rest match {
       case List(s_nscMjar, s_rscMjar) =>
         val nscMjar = Paths.get(s_nscMjar)
         val rscMjar = Paths.get(s_rscMjar)
-        Right(Settings(nscMjar, rscMjar))
+        val quiet = flags.contains("--quiet")
+        Right(Settings(nscMjar, rscMjar, quiet))
       case _ =>
-        Left(List("usage: diffmjar <nsc_mjar> <rsc_mjar>"))
+        Left(List("usage: diffmjar [--quiet] <nsc_mjar> <rsc_mjar>"))
     }
   }
 }

--- a/check/src/main/scala/rsc/diffoutline/Main.scala
+++ b/check/src/main/scala/rsc/diffoutline/Main.scala
@@ -4,7 +4,7 @@ package rsc.diffoutline
 
 import java.nio.file._
 import rsc.checkbase._
-import rsc.checkoutline.Checker
+import rsc.checkoutline
 
 object Main extends SimpleBase[Settings, Path, Path] {
   def settings(args: List[String]) = {
@@ -19,7 +19,8 @@ object Main extends SimpleBase[Settings, Path, Path] {
     Right(settings.rscOutline)
   }
 
-  def checker(nscResult: Path, rscResult: Path) = {
-    new Checker(nscResult, rscResult)
+  def checker(settings: Settings, nscResult: Path, rscResult: Path) = {
+    val checkerSettings = checkoutline.Settings(quiet = settings.quiet)
+    new checkoutline.Checker(checkerSettings, nscResult, rscResult)
   }
 }

--- a/check/src/main/scala/rsc/diffoutline/Settings.scala
+++ b/check/src/main/scala/rsc/diffoutline/Settings.scala
@@ -3,18 +3,22 @@
 package rsc.diffoutline
 
 import java.nio.file._
+import rsc.checkbase._
 
-final case class Settings(nscOutline: Path, rscOutline: Path)
+final case class Settings(nscOutline: Path, rscOutline: Path, quiet: Boolean) extends SettingsBase
 
+// FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {
   def parse(args: List[String]): Either[List[String], Settings] = {
-    args match {
+    val (flags, rest) = args.partition(_.startsWith("--"))
+    rest match {
       case List(s_nscOutline, s_rscOutline) =>
         val nscOutline = Paths.get(s_nscOutline)
         val rscOutline = Paths.get(s_rscOutline)
-        Right(Settings(nscOutline, rscOutline))
+        val quiet = flags.contains("--quiet")
+        Right(Settings(nscOutline, rscOutline, quiet))
       case _ =>
-        Left(List("usage: diffoutline <nsc_outline> <rsc_outline>"))
+        Left(List("usage: diffoutline [--quiet] <nsc_outline> <rsc_outline>"))
     }
   }
 }

--- a/check/src/main/scala/rsc/diffoutline/Settings.scala
+++ b/check/src/main/scala/rsc/diffoutline/Settings.scala
@@ -5,7 +5,8 @@ package rsc.diffoutline
 import java.nio.file._
 import rsc.checkbase._
 
-final case class Settings(nscOutline: Path, rscOutline: Path, quiet: Boolean) extends SettingsBase
+final case class Settings(nscOutline: Path, rscOutline: Path, quiet: Boolean)
+    extends SettingsBase
 
 // FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {

--- a/mjar/mjar/src/main/scala/scala/meta/mjar/Settings.scala
+++ b/mjar/mjar/src/main/scala/scala/meta/mjar/Settings.scala
@@ -35,6 +35,7 @@ final class Settings private (
   }
 }
 
+// FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {
   def parse(args: List[String], reporter: Reporter): Option[Settings] = {
     def loop(

--- a/mjar/scalap/src/main/scala/scala/meta/scalap/Settings.scala
+++ b/mjar/scalap/src/main/scala/scala/meta/scalap/Settings.scala
@@ -29,6 +29,7 @@ final class Settings private (
   }
 }
 
+// FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {
   def parse(args: List[String], reporter: Reporter): Option[Settings] = {
     def loop(

--- a/rsc/src/main/scala/rsc/cli/Main.scala
+++ b/rsc/src/main/scala/rsc/cli/Main.scala
@@ -17,13 +17,14 @@ object Main {
 
   def process(args: Array[String]): Boolean = {
     val expandedArgs = {
-      args match {
-        case Array(arg) if arg.startsWith("@") =>
+      args.toList.flatMap { arg =>
+        if (arg.startsWith("@")) {
           val argPath = Paths.get(arg.substring(1))
           val argText = new String(Files.readAllBytes(argPath), UTF_8)
           argText.split(EOL).map(_.trim).filter(_.nonEmpty).toList
-        case other =>
-          other.toList
+        } else {
+          List(arg)
+        }
       }
     }
     Settings.parse(expandedArgs) match {

--- a/rsc/src/main/scala/rsc/lexis/Names.scala
+++ b/rsc/src/main/scala/rsc/lexis/Names.scala
@@ -45,7 +45,11 @@ trait Names {
     }
 
     def isPatVar: Boolean = {
-      value.nonEmpty && value.head.isLower && value.head.isLetter
+      if (value.isEmpty) false
+      else if (value == "false" || value == "true" || value == "null") false
+      else {
+        (value.head.isLower && value.head.isLetter) || (value.head == '_')
+      }
     }
   }
 }

--- a/rsc/src/main/scala/rsc/lexis/Tokens.scala
+++ b/rsc/src/main/scala/rsc/lexis/Tokens.scala
@@ -83,7 +83,9 @@ trait Tokens {
   final val WHILE = 76
   final val WHITESPACE = 77
   final val WITH = 78
-  final val YIELD = 79
+  // FIXME: https://github.com/twitter/rsc/issues/81
+  final val XML = 79
+  final val YIELD = 80
 
   type Token = Int
 

--- a/rsc/src/main/scala/rsc/outline/Scheduler.scala
+++ b/rsc/src/main/scala/rsc/outline/Scheduler.scala
@@ -223,6 +223,8 @@ final class Scheduler private (
             case _ =>
               ()
           }
+        case PatXml(_) =>
+          ()
       }
     }
     mods(env, tree.mods)

--- a/rsc/src/main/scala/rsc/parse/Enumerators.scala
+++ b/rsc/src/main/scala/rsc/parse/Enumerators.scala
@@ -8,19 +8,22 @@ trait Enumerators {
 
   def enumerators(): List[Enumerator] = {
     val enumerators = List.newBuilder[Enumerator]
-    if (in.token.isStatSep) {
-      acceptStatSepUnlessAtEnd()
+    enumerators += firstEnumerator()
+    while (in.token.isStatSep) {
+      in.nextToken()
+      enumerators += otherEnumerator()
     }
-    while (in.token.isTermIntro) {
-      enumerators += enumerator()
-      if (in.token.isStatSep) {
-        acceptStatSepUnlessAtEnd()
-      }
-    }
-    enumerators.result()
+    enumerators.result
   }
 
-  def enumerator(): Enumerator = {
+  private def firstEnumerator(): Enumerator = {
+    val pat = infixPat(permitColon = true)
+    accept(LARROW)
+    val rhs = term()
+    EnumeratorGenerator(pat, rhs)
+  }
+
+  private def otherEnumerator(): Enumerator = {
     if (in.token == IF) {
       in.nextToken()
       val cond = postfixTerm()

--- a/rsc/src/main/scala/rsc/parse/Enumerators.scala
+++ b/rsc/src/main/scala/rsc/parse/Enumerators.scala
@@ -9,8 +9,8 @@ trait Enumerators {
   def enumerators(): List[Enumerator] = {
     val enumerators = List.newBuilder[Enumerator]
     enumerators += firstEnumerator()
-    while (in.token.isStatSep) {
-      in.nextToken()
+    while (in.token.isStatSep || in.token == IF) {
+      if (in.token.isStatSep) in.nextToken()
       enumerators += otherEnumerator()
     }
     enumerators.result

--- a/rsc/src/main/scala/rsc/parse/Groups.scala
+++ b/rsc/src/main/scala/rsc/parse/Groups.scala
@@ -20,10 +20,11 @@ trait Groups {
     val defn = packageDefn | templateDefn | localDefn | refineDefn
     private val term1 = BitSet(DO, FOR, ID, IF, INTID, LBRACE, LPAREN, NEW)
     private val term2 = BitSet(RETURN, SUPER, THIS, THROW, USCORE, TRY, WHILE)
-    val term = litTokens.all | term1 | term2
+    private val term3 = BitSet(XML)
+    val term = litTokens.all | term1 | term2 | term3
     val stat = term | defn | BitSet(IMPORT)
     val tpt = BitSet(AT, ID, LPAREN, SUPER, THIS, USCORE)
-    val pat = litTokens.all | BitSet(ID, INTID, LPAREN, THIS, USCORE)
+    val pat = litTokens.all | BitSet(ID, INTID, LPAREN, THIS, USCORE, XML)
   }
 
   object litTokens {
@@ -51,7 +52,7 @@ trait Groups {
 
   object outroTokens {
     private val term1 = BitSet(ID, INTEND, RBRACE, RBRACKET, RETURN)
-    private val term2 = BitSet(RPAREN, SUPER, THIS, USCORE)
+    private val term2 = BitSet(RPAREN, SUPER, THIS, USCORE, XML)
     val term = litTokens.all | term1 | term2
     val stat = term | BitSet(TYPE)
   }

--- a/rsc/src/main/scala/rsc/parse/Messages.scala
+++ b/rsc/src/main/scala/rsc/parse/Messages.scala
@@ -20,7 +20,7 @@ trait Messages {
   def reportPos(pos: Position, msgFn: Position => Message): Message = {
     val msg = msgFn(pos)
     if (msg.sev != FatalSeverity) {
-      crash(msg)
+      crash(msg.str)
     }
     reporter.append(msg)
   }
@@ -40,7 +40,7 @@ trait Messages {
     val msg = msgFn(pos)
     reporter.append(msg)
     if (msg.sev == FatalSeverity) {
-      crash(msg)
+      crash(msg.str)
     }
     msg
   }

--- a/rsc/src/main/scala/rsc/parse/Pats.scala
+++ b/rsc/src/main/scala/rsc/parse/Pats.scala
@@ -165,6 +165,11 @@ trait Pats {
         }
         accept(INTEND)
         atPos(start)(PatInterpolate(id, parts.result, args.result))
+      case XML =>
+        // FIXME: https://github.com/twitter/rsc/issues/81
+        val raw = in.value
+        in.nextToken()
+        atPos(start)(PatXml(raw))
       case _ =>
         val errOffset = in.offset
         reportOffset(errOffset, IllegalStartOfSimplePat)

--- a/rsc/src/main/scala/rsc/parse/Terms.scala
+++ b/rsc/src/main/scala/rsc/parse/Terms.scala
@@ -31,67 +31,13 @@ trait Terms {
 
   def term(location: Location = Elsewhere): Term = {
     if (in.token == IMPLICIT) {
-      in.nextToken()
-      val id = {
-        if (in.token == ID) {
-          termId()
-        } else if (in.token == USCORE) {
-          in.nextToken()
-          anonId()
-        } else {
-          accept(ID)
-        }
-      }
-      accept(ARROW)
-      val rhs = term(location)
-      crash("https://github.com/twitter/rsc/issues/102")
+      implicitLambda(location)
     } else {
       wrapEscapingTermWildcards {
         val start = in.offset
         val unfinished = term1(location)
         if (in.token == ARROW) {
-          in.nextToken()
-          val unfinishedReinterpretedAsParams = {
-            object ParamLike {
-              def unapply(term: Term): Option[Param] = {
-                val mods = atPos(term.pos.start, term.pos.start)(Mods(Nil))
-                term match {
-                  case id: TermId =>
-                    Some(atPos(term.pos)(Param(mods, id, None, None)))
-                  case TermAscribe(id: TermId, tpt) =>
-                    Some(atPos(term.pos)(Param(mods, id, Some(tpt), None)))
-                  case wildcard @ TermWildcard() =>
-                    val id = reinterpretAsParam(wildcard)
-                    Some(atPos(term.pos)(Param(mods, id, None, None)))
-                  case TermAscribe(wildcard @ TermWildcard(), tpt) =>
-                    val id = reinterpretAsParam(wildcard)
-                    Some(atPos(term.pos)(Param(mods, id, Some(tpt), None)))
-                  case _ =>
-                    None
-                }
-              }
-            }
-            unfinished match {
-              case TermLit(()) =>
-                Nil
-              case ParamLike(param) =>
-                List(param)
-              case TermTuple(args) =>
-                val params = args.flatMap(ParamLike.unapply)
-                if (args.length != params.length) crash(unfinished)
-                params
-              case _ =>
-                crash(unfinished)
-            }
-          }
-          val body =
-            if (location == InBlock) {
-              blockStats() match {
-                case List(stat: TermBlock) => stat
-                case stats => TermBlock(stats)
-              }
-            } else term()
-          atPos(start)(TermFunction(unfinishedReinterpretedAsParams, body))
+          lambdaRest(start, unfinished, location)
         } else {
           unfinished
         }
@@ -393,6 +339,85 @@ trait Terms {
     }
   }
 
+  private def lambdaRest(
+      start: Offset,
+      unfinished: Term,
+      location: Location): TermFunction = {
+    accept(ARROW)
+    val unfinishedReinterpretedAsParams = {
+      object ParamLike {
+        def unapply(term: Term): Option[Param] = {
+          val mods = atPos(term.pos.start, term.pos.start)(Mods(Nil))
+          term match {
+            case id: TermId =>
+              Some(atPos(term.pos)(Param(mods, id, None, None)))
+            case TermAscribe(id: TermId, tpt) =>
+              Some(atPos(term.pos)(Param(mods, id, Some(tpt), None)))
+            case wildcard @ TermWildcard() =>
+              val id = reinterpretAsParam(wildcard)
+              Some(atPos(term.pos)(Param(mods, id, None, None)))
+            case TermAscribe(wildcard @ TermWildcard(), tpt) =>
+              val id = reinterpretAsParam(wildcard)
+              Some(atPos(term.pos)(Param(mods, id, Some(tpt), None)))
+            case _ =>
+              None
+          }
+        }
+      }
+      unfinished match {
+        case TermLit(()) =>
+          Nil
+        case ParamLike(param) =>
+          List(param)
+        case TermTuple(args) =>
+          val params = args.flatMap(ParamLike.unapply)
+          if (args.length != params.length) crash(unfinished)
+          params
+        case _ =>
+          crash(unfinished)
+      }
+    }
+    val body = lambdaBody(location)
+    atPos(start)(TermFunction(unfinishedReinterpretedAsParams, body))
+  }
+
+  private def implicitLambda(location: Location): TermFunction = {
+    val start = in.offset
+    val mods = {
+      accept(IMPLICIT)
+      val mod = atPos(start)(ModImplicit())
+      atPos(start)(Mods(List(mod)))
+    }
+    val id = termId()
+    val tpt = {
+      if (in.token == COLON) {
+        in.nextToken()
+        if (location == Elsewhere) Some(this.tpt())
+        else Some(this.infixTpt())
+      } else {
+        None
+      }
+    }
+    val params = {
+      val param = atPos(start)(Param(mods, id, tpt, None))
+      List(param)
+    }
+    accept(ARROW)
+    val body = lambdaBody(location)
+    atPos(start)(TermFunction(params, body))
+  }
+
+  private def lambdaBody(location: Location): Term = {
+    if (location == InBlock) {
+      blockStats() match {
+        case List(stat: Term) => stat
+        case stats => TermBlock(stats)
+      }
+    } else {
+      term()
+    }
+  }
+
   def errorTerm(): Term = {
     TermId(gensym.error())
   }
@@ -418,46 +443,61 @@ trait Terms {
       } else if (in.token.isTermIntro) {
         stats += term(InBlock)
       } else if (in.token.isLocalDefnIntro) {
-        val start = in.offset
-        val mods = defnMods(modTokens.localDefn)
-        val stat = in.token match {
-          case CASECLASS =>
-            val modCase = atPos(in.offset)(ModCase())
+        val isImplicitLambda = {
+          if (in.token == IMPLICIT) {
+            val snapshot = in.snapshot()
             in.nextToken()
-            defnClass(atPos(mods.pos.start)(Mods(mods.trees :+ modCase)))
-          case CASEOBJECT =>
-            val modCase = atPos(in.offset)(ModCase())
-            in.nextToken()
-            defnObject(atPos(mods.pos.start)(Mods(mods.trees :+ modCase)))
-          case CLASS =>
-            in.nextToken()
-            defnClass(mods)
-          case DEF =>
-            in.nextToken()
-            defnDef(mods)
-          case OBJECT =>
-            in.nextToken()
-            defnObject(mods)
-          case TRAIT =>
-            in.nextToken()
-            defnTrait(mods)
-          case TYPE =>
-            in.nextToken()
-            defnType(mods)
-          case VAL =>
-            val modVal = atPos(in.offset)(ModVal())
-            in.nextToken()
-            defnVal(atPos(mods.pos.start)(Mods(mods.trees :+ modVal)))
-          case VAR =>
-            val modVar = atPos(in.offset)(ModVar())
-            in.nextToken()
-            defnVar(atPos(mods.pos.start)(Mods(mods.trees :+ modVar)))
-          case _ =>
-            val errOffset = in.offset
-            reportOffset(errOffset, ExpectedStartOfDefinition)
-            atPos(errOffset)(errorStat())
+            val result = in.token == ID
+            in.restore(snapshot)
+            result
+          } else {
+            false
+          }
         }
-        stats += stat
+        if (isImplicitLambda) {
+          stats += implicitLambda(InBlock)
+        } else {
+          val start = in.offset
+          val mods = defnMods(modTokens.localDefn)
+          val stat = in.token match {
+            case CASECLASS =>
+              val modCase = atPos(in.offset)(ModCase())
+              in.nextToken()
+              defnClass(atPos(mods.pos.start)(Mods(mods.trees :+ modCase)))
+            case CASEOBJECT =>
+              val modCase = atPos(in.offset)(ModCase())
+              in.nextToken()
+              defnObject(atPos(mods.pos.start)(Mods(mods.trees :+ modCase)))
+            case CLASS =>
+              in.nextToken()
+              defnClass(mods)
+            case DEF =>
+              in.nextToken()
+              defnDef(mods)
+            case OBJECT =>
+              in.nextToken()
+              defnObject(mods)
+            case TRAIT =>
+              in.nextToken()
+              defnTrait(mods)
+            case TYPE =>
+              in.nextToken()
+              defnType(mods)
+            case VAL =>
+              val modVal = atPos(in.offset)(ModVal())
+              in.nextToken()
+              defnVal(atPos(mods.pos.start)(Mods(mods.trees :+ modVal)))
+            case VAR =>
+              val modVar = atPos(in.offset)(ModVar())
+              in.nextToken()
+              defnVar(atPos(mods.pos.start)(Mods(mods.trees :+ modVar)))
+            case _ =>
+              val errOffset = in.offset
+              reportOffset(errOffset, ExpectedStartOfDefinition)
+              atPos(errOffset)(errorStat())
+          }
+          stats += stat
+        }
       } else if (!in.token.isStatSep && in.token != CASE) {
         exitOnError = in.token.mustStartStat
         val errOffset = in.offset

--- a/rsc/src/main/scala/rsc/parse/Terms.scala
+++ b/rsc/src/main/scala/rsc/parse/Terms.scala
@@ -294,6 +294,11 @@ trait Terms {
         }
         accept(INTEND)
         atPos(start)(TermInterpolate(id, parts.result(), args.result()))
+      case XML =>
+        // FIXME: https://github.com/twitter/rsc/issues/81
+        val raw = in.value
+        in.nextToken()
+        atPos(start)(TermXml(raw))
       case _ =>
         if (in.token.isLit) {
           canApply = true

--- a/rsc/src/main/scala/rsc/pretty/PrettyToken.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyToken.scala
@@ -93,6 +93,7 @@ object PrettyToken {
       case WHILE => ("while", "WHILE")
       case WHITESPACE => ("whitespace", "WHITESPACE")
       case WITH => ("with", "WITH")
+      case XML => ("xml literal", "XML")
       case YIELD => ("yield", "YIELD")
       case 256 => ("case class", "CASECLASS")
       case 257 => ("case object", "CASEOBJECT")

--- a/rsc/src/main/scala/rsc/pretty/TreeStr.scala
+++ b/rsc/src/main/scala/rsc/pretty/TreeStr.scala
@@ -328,6 +328,9 @@ class TreeStr(val p: Printer) {
           case _ => apply(id)
         }
         p.Prefix(": ")(tpt)(apply(_, "", RefineTyp))
+      case PatXml(raw) =>
+        // FIXME: https://github.com/twitter/rsc/issues/81
+        p.str(raw)
       case tree @ PrimaryCtor(mods, paramss) =>
         if (mods.trees.nonEmpty) p.str(" ")
         apply(mods)
@@ -524,6 +527,9 @@ class TreeStr(val p: Printer) {
         p.str("_")
       case TermWildcardFunction(_, term) =>
         apply(term, Expr)
+      case TermXml(raw) =>
+        // FIXME: https://github.com/twitter/rsc/issues/81
+        p.str(raw)
       case TptAnnotate(tpt, mods) =>
         apply(tpt, SimpleTyp)
         p.str(" ")

--- a/rsc/src/main/scala/rsc/pretty/TreeStr.scala
+++ b/rsc/src/main/scala/rsc/pretty/TreeStr.scala
@@ -625,7 +625,7 @@ class TreeStr(val p: Printer) {
             simpleValue match {
               case Some(value) =>
                 value.exists(!_.isLetter) ||
-                isSpliceIdPart(part.headOption.getOrElse('_'))
+                  isSpliceIdPart(part.headOption.getOrElse('_'))
               case None =>
                 true
             }
@@ -663,8 +663,8 @@ class TreeStr(val p: Printer) {
                 true
               case Some(prev: Term) =>
                 next.isInstanceOf[TermBlock] ||
-                next.isInstanceOf[TermPartialFunction] ||
-                next.isInstanceOf[TermFunction]
+                  next.isInstanceOf[TermPartialFunction] ||
+                  next.isInstanceOf[TermFunction]
               case _ =>
                 false
             }

--- a/rsc/src/main/scala/rsc/pretty/TreeStr.scala
+++ b/rsc/src/main/scala/rsc/pretty/TreeStr.scala
@@ -194,9 +194,10 @@ class TreeStr(val p: Printer) {
         p.Suffix(" ")(trees)(apply(_, " "))
       case ModAbstract() =>
         p.str("abstract")
-      case ModAnnotation(init) =>
+      case ModAnnotation(Init(tpt, argss)) =>
         p.str("@")
-        apply(init)
+        apply(tpt, SimpleTyp)
+        apply(argss, Expr)
       case ModCase() =>
         p.str("case")
       case ModContravariant() =>

--- a/rsc/src/main/scala/rsc/pretty/TreeStr.scala
+++ b/rsc/src/main/scala/rsc/pretty/TreeStr.scala
@@ -155,14 +155,20 @@ class TreeStr(val p: Printer) {
       case EnumeratorGenerator(pat, rhs) =>
         apply(pat, AnyPat3)
         p.str(" <- ")
-        apply(rhs, Expr)
+        rhs match {
+          case _: TermApplyPostfix => p.Parens(apply(rhs, Expr))
+          case _ => apply(rhs, Expr)
+        }
       case EnumeratorGuard(cond) =>
         p.str("if ")
         apply(cond, PostfixExpr)
       case EnumeratorVal(pat, rhs) =>
         apply(pat, AnyPat3)
         p.str(" = ")
-        apply(rhs, Expr)
+        rhs match {
+          case _: TermApplyPostfix => p.Parens(apply(rhs, Expr))
+          case _ => apply(rhs, Expr)
+        }
       case Import(importers) =>
         p.str("import ")
         apply(importers, ", ")

--- a/rsc/src/main/scala/rsc/pretty/TreeStr.scala
+++ b/rsc/src/main/scala/rsc/pretty/TreeStr.scala
@@ -609,13 +609,21 @@ class TreeStr(val p: Printer) {
         stats(i + 1) match {
           case next: Term =>
             def needsSemicolon(prev: Option[Tree]): Boolean = prev match {
-              case Some(prev: DefnField) => needsSemicolon(prev.rhs)
-              case Some(prev: DefnMacro) => needsSemicolon(Some(prev.rhs))
-              case Some(prev: DefnMethod) => needsSemicolon(prev.rhs)
-              case Some(prev: DefnPat) => needsSemicolon(prev.rhs)
-              case Some(prev: TermApplyPostfix) => true
-              case Some(prev: Term) => next.isInstanceOf[TermBlock]
-              case _ => false
+              case Some(prev: DefnField) =>
+                needsSemicolon(prev.rhs)
+              case Some(prev: DefnMacro) =>
+                needsSemicolon(Some(prev.rhs))
+              case Some(prev: DefnMethod) =>
+                needsSemicolon(prev.rhs)
+              case Some(prev: DefnPat) =>
+                needsSemicolon(prev.rhs)
+              case Some(prev: TermApplyPostfix) =>
+                true
+              case Some(prev: Term) =>
+                next.isInstanceOf[TermBlock] ||
+                next.isInstanceOf[TermPartialFunction]
+              case _ =>
+                false
             }
             if (needsSemicolon(Some(stat))) {
               p.str(";")

--- a/rsc/src/main/scala/rsc/pretty/TreeStr.scala
+++ b/rsc/src/main/scala/rsc/pretty/TreeStr.scala
@@ -507,6 +507,7 @@ class TreeStr(val p: Printer) {
         val params :+ ret = targs
         val needsParens = params match {
           case List(_: TptTuple | _: TptFunction) => true
+          case List(_: TptByName | _: TptRepeat) => true
           case List(_) => false
           case _ => true
         }

--- a/rsc/src/main/scala/rsc/pretty/TreeStr.scala
+++ b/rsc/src/main/scala/rsc/pretty/TreeStr.scala
@@ -585,8 +585,11 @@ class TreeStr(val p: Printer) {
               case _ => None
             }
             simpleValue match {
-              case Some(_) => isSpliceIdPart(part.headOption.getOrElse('_'))
-              case None => true
+              case Some(value) =>
+                value.exists(!_.isLetter) ||
+                isSpliceIdPart(part.headOption.getOrElse('_'))
+              case None =>
+                true
             }
           }
           if (needBraces) p.Braces(apply(arg))

--- a/rsc/src/main/scala/rsc/pretty/TreeStr.scala
+++ b/rsc/src/main/scala/rsc/pretty/TreeStr.scala
@@ -578,7 +578,7 @@ class TreeStr(val p: Printer) {
       args.zip(parts.drop(1)).foreach {
         case (arg, part) =>
           p.str("$")
-          val needBraces = {
+          val needsBraces = {
             val simpleValue = arg match {
               case TermId(value) => Some(value)
               case PatVar(TermId(value), _) => Some(value)
@@ -592,7 +592,7 @@ class TreeStr(val p: Printer) {
                 true
             }
           }
-          if (needBraces) p.Braces(apply(arg))
+          if (needsBraces) p.Braces(apply(arg))
           else apply(arg)
           p.ignoringIndent(p.str(part))
       }

--- a/rsc/src/main/scala/rsc/pretty/Weights.scala
+++ b/rsc/src/main/scala/rsc/pretty/Weights.scala
@@ -48,6 +48,7 @@ trait Weights {
         case _: PatTuple => SimplePat
         case PatVar(_, None) => SimplePat
         case PatVar(_, Some(_)) => Pat1
+        case _: PatXml => SimplePat
         case _: TermAnnotate => Expr1
         case _: TermApply => SimpleExpr1
         case tree: TermApplyInfix => InfixExpr(tree.op)
@@ -83,6 +84,7 @@ trait Weights {
         case _: TermWhile => Expr1
         case _: TermWildcard => SimpleExpr1
         case _: TermWildcardFunction => Expr1
+        case _: TermXml => SimpleExpr1
         case _: TptAnnotate => AnnotTyp
         case _: TptByName => ParamTyp
         case _: TptExistential => Typ

--- a/rsc/src/main/scala/rsc/report/Messages.scala
+++ b/rsc/src/main/scala/rsc/report/Messages.scala
@@ -68,6 +68,11 @@ final case class IllegalNumber(pos: Position) extends Message {
   def text = "illegal number"
 }
 
+final case class IllegalXml(pos: Position) extends Message {
+  def sev = FatalSeverity
+  def text = "illegal xml"
+}
+
 final case class LeadingZero(pos: Position) extends Message {
   def sev = FatalSeverity
   def text = "leading zeros not allowed"

--- a/rsc/src/main/scala/rsc/scan/Messages.scala
+++ b/rsc/src/main/scala/rsc/scan/Messages.scala
@@ -14,7 +14,7 @@ trait Messages {
     val msg = msgFn(pos)
     reporter.append(msg)
     if (msg.sev == FatalSeverity) {
-      crash(msg)
+      crash(msg.str)
     }
     msg
   }

--- a/rsc/src/main/scala/rsc/scan/Scanner.scala
+++ b/rsc/src/main/scala/rsc/scan/Scanner.scala
@@ -15,7 +15,8 @@ final class Scanner private (
     val input: Input)
     extends Characters
     with History
-    with Messages {
+    with Messages
+    with Xml {
   var start: Offset = 0
   var end: Offset = 0
   var token: Token = BOF
@@ -251,7 +252,7 @@ final class Scanner private (
         def xmlPre = token == WHITESPACE || token == LPAREN || token == LBRACE
         def xmlSuf = isXmlNameStart(ch1) || ch1 == '!' || ch1 == '?'
         if (xmlPre && xmlSuf) {
-          crash("unsupported: xml literals")
+          xml()
         } else {
           symbolicIdOrKeyword()
         }
@@ -634,7 +635,7 @@ final class Scanner private (
     emit(WHITESPACE, null)
   }
 
-  private def emit(token: Token, value: String): Unit = {
+  def emit(token: Token, value: String): Unit = {
     this.start = end
     this.end = offset
     this.token = token

--- a/rsc/src/main/scala/rsc/scan/Xml.scala
+++ b/rsc/src/main/scala/rsc/scan/Xml.scala
@@ -1,0 +1,160 @@
+// Copyright (c) 2017-2018 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+// NOTE: This file has been partially copy/pasted from scalameta/scalameta.
+package rsc.scan
+
+import fastparse.all._
+import fastparse.core.{Mutable, Parsed}
+import rsc.lexis._
+import rsc.report._
+
+trait Xml {
+  self: Scanner =>
+
+  // FIXME: https://github.com/twitter/rsc/issues/81
+  def xml(): Unit = {
+    val start = offset
+    val parsed = XmlSkipper.XmlExpr.parse(input.string, index = start)
+    parsed match {
+      case Parsed.Success(_, end) =>
+        offset = end
+        val lexeme = new String(chs, start, end - start)
+        emit(XML, lexeme)
+      case Parsed.Failure(_, failIndex, extra) =>
+        val message = reportOffset(failIndex, IllegalXml)
+        emit(ERROR, message.str)
+    }
+  }
+
+  /**
+    * Copy-pasta from this lihaoyi comment:
+    * [[https://github.com/scalameta/fastparse/pull/1#issuecomment-244940542]]
+    * and adapted to more closely match scala-xml.
+    * upd. Further simplified upon a second round of copy-pasta.
+    */
+  private object XmlSkipper {
+
+    private val S = CharsWhileIn("\t\n\r ")
+
+    val XmlExpr: P0 = P( Xml.XmlContent.rep(min = 1, sep = S.?) )
+    // FIXME: https://github.com/twitter/rsc/issues/81
+    // val XmlPattern: P0 = P( Xml.ElemPattern )
+
+    private[this] object Xml {
+      val Element   = P( TagHeader ~/ ("/>" | ">" ~/ Content ~/ ETag ) ) // FIXME tag must be balanced
+      val TagHeader = P( "<" ~ Name ~/ (S ~ Attribute).rep ~ S.? )
+      val ETag      = P( "</" ~ Name ~ S.? ~ ">" )
+
+      val Attribute = P( Name ~/ Eq ~/ AttValue )
+      val Eq        = P( S.? ~ "=" ~ S.? )
+      val AttValue  = P(
+        "\"" ~/ (CharQ | Reference).rep ~ "\"" |
+          "'" ~/ (CharA | Reference).rep ~ "'" |
+          ScalaExpr
+      )
+
+      val Content        = P( (CharData | Reference | ScalaExpr | XmlContent).rep )
+      val XmlContent: P0 = P( Unparsed | CDSect | PI | Comment | Element )
+
+      val ScalaExpr = P( "{" ~ TermSkipper ~ "}" )
+
+      val Unparsed = P( UnpStart ~/ UnpData ~ UnpEnd )
+      val UnpStart = P( "<xml:unparsed" ~/ (S ~ Attribute).rep ~ S.? ~ ">" )
+      val UnpEnd   = P( "</xml:unparsed>" )
+      val UnpData  = P( (!UnpEnd ~ Char).rep )
+
+      val CDSect  = P( CDStart ~/ CData ~ CDEnd )
+      val CDStart = P( "<![CDATA[" )
+      val CData   = P( (!"]]>" ~ Char).rep )
+      val CDEnd   = P( "]]>" )
+
+      val Comment = P( "<!--" ~/ ComText ~ "-->" )
+      val ComText = P( (!"-->" ~ Char).rep )
+
+      val PI         = P( "<?" ~ Name ~ S.? ~ PIProcText ~ "?>" )
+      val PIProcText = P( (!"?>" ~ Char).rep )
+
+      val Reference = P( EntityRef | CharRef )
+      val EntityRef = P( "&" ~ Name ~/ ";" )
+      val CharRef   = P( "&#" ~ Num ~ ";" | "&#x" ~ HexNum ~ ";" )
+      val Num       = P( CharIn('0' to '9').rep )
+      val HexNum    = P( CharIn('0' to '9', 'a' to 'f', 'A' to 'F').rep )
+
+      val CharData = P( (CharB | "{{" | "}}").rep(1) )
+
+      val Char   = P( AnyChar )
+      val Char1  = P( !("<" | "&") ~ Char )
+      val CharQ  = P( !"\"" ~ Char1 )
+      val CharA  = P( !"'" ~ Char1 )
+      val CharB  = P( !("{" | "}") ~ Char1 )
+
+      val Name: P0  = P( NameStart ~ NameChar.rep ).!.filter(_.last != ':').opaque("Name").map(_ => Unit) // discard result
+      val NameStart = P( CharPred.raw(isNameStart) )
+      val NameChar  = P( CharPred.raw(isNameChar) )
+
+      //================================================================================
+      // From `scala.xml.parsing.TokenTests`
+      //================================================================================
+
+      /**
+       * {{{
+       *  NameChar ::= Letter | Digit | '.' | '-' | '_' | ':'
+       *             | CombiningChar | Extender
+       *  }}}
+       *  See [4] and Appendix B of XML 1.0 specification.
+       */
+      def isNameChar(ch: Char) = {
+        import java.lang.Character._
+        // The constants represent groups Mc, Me, Mn, Lm, and Nd.
+
+        isNameStart(ch) || (getType(ch).toByte match {
+          case COMBINING_SPACING_MARK |
+            ENCLOSING_MARK | NON_SPACING_MARK |
+            MODIFIER_LETTER | DECIMAL_DIGIT_NUMBER => true
+          case _ => ".-:" contains ch
+        })
+      }
+
+      /**
+       * {{{
+       *  NameStart ::= ( Letter | '_' )
+       *  }}}
+       *  where Letter means in one of the Unicode general
+       *  categories `{ Ll, Lu, Lo, Lt, Nl }`.
+       *
+       *  We do not allow a name to start with `:`.
+       *  See [3] and Appendix B of XML 1.0 specification
+       */
+      def isNameStart(ch: Char) = {
+        import java.lang.Character._
+
+        getType(ch).toByte match {
+          case LOWERCASE_LETTER |
+            UPPERCASE_LETTER | OTHER_LETTER |
+            TITLECASE_LETTER | LETTER_NUMBER => true
+          case _ => ch == '_'
+        }
+      }
+    }
+  }
+
+  object TermSkipper extends Parser[Unit] {
+    def parseRec(cfg: ParseCtx, index: Int): Mutable[Unit, Char, String] = {
+      var blevel = 1
+      val input = cfg.input
+      val scanner = Scanner(self.settings, self.reporter, self.input)
+      scanner.offset = index
+      while (blevel > 0) {
+        scanner.next()
+        scanner.token match {
+          case LBRACE => blevel += 1
+          case RBRACE => blevel -= 1
+          case EOF => return fail(cfg.failure, index + scanner.offset)
+          case _ => ()
+        }
+      }
+      val nextIndex = scanner.offset - 1
+      success(cfg.success, (), nextIndex, Set.empty, cut = false)
+    }
+  }
+}

--- a/rsc/src/main/scala/rsc/settings/Settings.scala
+++ b/rsc/src/main/scala/rsc/settings/Settings.scala
@@ -14,6 +14,7 @@ final case class Settings(
     ystopAfter: Set[String] = Set[String]()
 )
 
+// FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {
   def parse(args: List[String]): Option[Settings] = {
     def loop(

--- a/rsc/src/main/scala/rsc/syntax/Dupe.scala
+++ b/rsc/src/main/scala/rsc/syntax/Dupe.scala
@@ -207,6 +207,8 @@ trait Dupe {
           val id1 = id.dupe
           val tpt1 = tpt.map(_.dupe)
           PatVar(id1, tpt1)
+        case PatXml(raw) =>
+          PatXml(raw)
         case PrimaryCtor(mods, paramss) =>
           val mods1 = mods.dupe
           val paramss1 = paramss.map(_.map(_.dupe))
@@ -353,6 +355,8 @@ trait Dupe {
           TermWhile(cond1, body1)
         case TermWildcard() =>
           TermWildcard()
+        case TermXml(raw) =>
+          TermXml(raw)
         case TermWildcardFunction(ids, body) =>
           val ids1 = ids.map(_.dupe)
           val body1 = body.dupe

--- a/rsc/src/main/scala/rsc/syntax/Trees.scala
+++ b/rsc/src/main/scala/rsc/syntax/Trees.scala
@@ -338,6 +338,9 @@ final case class PatVar(id: Id, tpt: Option[Tpt]) extends Pat with TermOutline {
   def mods = Mods(Nil)
 }
 
+// FIXME: https://github.com/twitter/rsc/issues/81
+final case class PatXml(raw: String) extends Pat
+
 sealed trait Path extends Tree {
   def id: Id
 }
@@ -477,6 +480,9 @@ final case class TermWildcard() extends Term {
 
 final case class TermWildcardFunction(ids: List[AnonId], body: Term)
     extends Term
+
+// FIXME: https://github.com/twitter/rsc/issues/81
+final case class TermXml(raw: String) extends Term
 
 sealed trait Tpt extends Tree
 

--- a/tests/src/main/scala/rsc/tests/FileFixtures.scala
+++ b/tests/src/main/scala/rsc/tests/FileFixtures.scala
@@ -3,9 +3,7 @@
 package rsc.tests
 
 import java.io.File.pathSeparator
-import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file._
-import rsc.pretty._
 import scala.collection.JavaConverters._
 
 trait FileFixtures extends ToolUtil {
@@ -37,22 +35,6 @@ trait FileFixtures extends ToolUtil {
 
   lazy val functionClasspath: List[Path] = {
     javaLibrary ++ BuildInfo.functionDeps.map(_.toPath).toList
-  }
-
-  lazy val externalFiles: List[Path] = {
-    sys.env.get("EXTERNAL_FILES") match {
-      case Some(listFile) =>
-        val listPath = Paths.get(listFile)
-        if (Files.exists(listPath)) {
-          val listText = new String(Files.readAllBytes(listPath), UTF_8)
-          val listLines = listText.split(EOL).map(_.trim).filter(_.nonEmpty)
-          listLines.map(s => Paths.get(s)).toList
-        } else {
-          Nil
-        }
-      case _ =>
-        Nil
-    }
   }
 
   lazy val javaLibrary: List[Path] = {

--- a/tests/src/test/scala/rsc/tests/MjarTests.scala
+++ b/tests/src/test/scala/rsc/tests/MjarTests.scala
@@ -6,7 +6,7 @@ import rsc.checkmjar._
 
 class MjarTests extends RscTests {
   test("mjar for core") {
-    val settings = Settings(coreClasspath, coreFiles)
+    val settings = Settings(coreClasspath, coreFiles, quiet = true)
     val problems = Main.process(settings)
     if (problems.nonEmpty) fail()
   }

--- a/tests/src/test/scala/rsc/tests/OutlineTests.scala
+++ b/tests/src/test/scala/rsc/tests/OutlineTests.scala
@@ -6,7 +6,7 @@ import rsc.checkoutline._
 
 class OutlineTests extends RscTests {
   test("outline for core") {
-    val settings = Settings(coreClasspath, coreFiles)
+    val settings = Settings(coreClasspath, coreFiles, quiet = true)
     val problems = Main.process(settings)
     if (problems.nonEmpty) fail()
   }

--- a/tests/src/test/scala/rsc/tests/ParseTests.scala
+++ b/tests/src/test/scala/rsc/tests/ParseTests.scala
@@ -6,13 +6,13 @@ import rsc.checkparse._
 
 class ParseTests extends RscTests {
   test("parse for core") {
-    val settings = Settings(coreFiles)
+    val settings = Settings(coreFiles, quiet = true)
     val problems = Main.process(settings)
     if (problems.nonEmpty) fail()
   }
 
   test("parse for external") {
-    val settings = Settings(externalFiles)
+    val settings = Settings(externalFiles, quiet = true)
     val problems = Main.process(settings)
     if (problems.nonEmpty) fail()
   }

--- a/tests/src/test/scala/rsc/tests/ParseTests.scala
+++ b/tests/src/test/scala/rsc/tests/ParseTests.scala
@@ -10,10 +10,4 @@ class ParseTests extends RscTests {
     val problems = Main.process(settings)
     if (problems.nonEmpty) fail()
   }
-
-  test("parse for external") {
-    val settings = Settings(externalFiles, quiet = true)
-    val problems = Main.process(settings)
-    if (problems.nonEmpty) fail()
-  }
 }


### PR DESCRIPTION
This pull request follows up on https://github.com/twitter/rsc/pull/133, providing a final round of bugfixes in our parser and prettyprinter and ensuring that checkparse succeeds on all Scala sources in a case study project.

Additionally, since the case study project is pretty sizable, I had to introduce progress tracking functionality. By default, all checkers now print progress and remaining time every 100 work items (but no more often than every 3 seconds). This can be disabled by providing the new `--quiet` command-line argument.