### PR TITLE
Stop persisting package outlines

### DIFF
--- a/check/src/main/scala/rsc/checkoutline/Checker.scala
+++ b/check/src/main/scala/rsc/checkoutline/Checker.scala
@@ -102,8 +102,6 @@ class Checker(nscResult: Path, rscResult: Path) extends CheckerBase {
     val indexOps = new IndexOps(index)
     import indexOps._
     var infos1 = index.infos.values.toList
-    // WONTFIX: https://github.com/scalameta/scalameta/issues/1340
-    infos1 = infos1.filter(_.kind != k.PACKAGE)
     // WONTFIX: https://github.com/twitter/rsc/issues/121
     infos1 = infos1.filter(_.isEligible)
     Index(infos1.map(info => info.symbol -> info).toMap, index.anchors)

--- a/mjar/mjar/src/main/scala/scala/meta/internal/mjar/Symtab.scala
+++ b/mjar/mjar/src/main/scala/scala/meta/internal/mjar/Symtab.scala
@@ -40,7 +40,7 @@ class Symtab private (
         case PACKAGE_OBJECT =>
           true
         case CLASS | INTERFACE | OBJECT | TRAIT =>
-          apply(info.symbol.owner).kind == PACKAGE
+          info.symbol.owner.desc.isPackage
         case _ =>
           false
       }

--- a/rsc/src/main/scala/rsc/semanticdb/Semanticdb.scala
+++ b/rsc/src/main/scala/rsc/semanticdb/Semanticdb.scala
@@ -75,16 +75,6 @@ final class Semanticdb private (
     }
   }
 
-  private def builtinPackage(sym: Symbol): s.SymbolInformation = {
-    s.SymbolInformation(
-      symbol = sym,
-      language = l.SCALA,
-      kind = k.PACKAGE,
-      name = sym.desc.value,
-      accessibility = Some(s.Accessibility(a.PUBLIC))
-    )
-  }
-
   def save(): Unit = {
     Files.createDirectories(settings.out.toAbsolutePath.getParent)
     val fos = Files.newOutputStream(settings.out)
@@ -98,8 +88,6 @@ final class Semanticdb private (
         var occurrences = occs.get(entry.getKey)
         if (occurrences == null) occurrences = UnrolledBuffer.empty
         val symbols = entry.getValue
-        symbols += builtinPackage(RootPackage)
-        symbols += builtinPackage(EmptyPackage)
         val document = s.TextDocument(
           schema = s.Schema.SEMANTICDB4,
           uri = cwd.relativize(entry.getKey.path.toAbsolutePath).toString,
@@ -118,7 +106,8 @@ final class Semanticdb private (
 
   implicit class EligibleSemanticdbOps(outline: Outline) {
     def isEligible: Boolean = {
-      outline.isVisible
+      if (outline.isInstanceOf[DefnPackage]) false
+      else outline.isVisible
     }
 
     def isVisible: Boolean = {


### PR DESCRIPTION
Following Scalameta (https://github.com/scalameta/scalameta/pull/1699), we are stopping persisting package SymbolInformation. Now that package symbols end with slashes, we no longer need infos to distinguish packages from everything else.