### PR TITLE
Increase maxColumn from 80 to 100

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,7 +6,7 @@ assumeStandardLibraryStripMargin = true
 binPack.parentConstructors = false
 danglingParentheses = false
 docstrings = JavaDoc
-maxColumn = 80
+maxColumn = 100
 project.excludeFilters = [
   "examples/.*",
   "scalafix/input/.*",

--- a/build.sbt
+++ b/build.sbt
@@ -225,8 +225,7 @@ lazy val publishableSettings = Seq(
   pomIncludeRepository := { x =>
     false
   },
-  licenses += "Apache v2" -> url(
-    "https://github.com/twitter/rsc/blob/master/LICENSE.md"),
+  licenses += "Apache v2" -> url("https://github.com/twitter/rsc/blob/master/LICENSE.md"),
   pomExtra := (
     <url>https://github.com/twitter/rsc</url>
     <inceptionYear>2017</inceptionYear>
@@ -264,8 +263,7 @@ lazy val semanticdbSettings = Def.settings(
   scalacOptions -= "-feature",
   scalacOptions -= "-Ywarn-unused-import",
   scalacOptions -= "-Xfatal-warnings",
-  addCompilerPlugin(
-    "org.scalameta" %% "semanticdb-scalac" % V.scalameta cross CrossVersion.full),
+  addCompilerPlugin("org.scalameta" %% "semanticdb-scalac" % V.scalameta cross CrossVersion.full),
   scalacOptions += "-Yrangepos",
   scalacOptions += "-P:semanticdb:text:off",
   scalacOptions += "-P:semanticdb:symbols:all",

--- a/check/src/main/scala/rsc/checkbase/MainBase.scala
+++ b/check/src/main/scala/rsc/checkbase/MainBase.scala
@@ -7,10 +7,7 @@ import scala.collection.mutable
 import scala.meta.internal.cli._
 import scala.util._
 
-trait MainBase[S <: SettingsBase, I, N, R]
-    extends DiffUtil
-    with NscUtil
-    with ToolUtil {
+trait MainBase[S <: SettingsBase, I, N, R] extends DiffUtil with NscUtil with ToolUtil {
   def main(args: Array[String]): Unit = {
     val expandedArgs = Args.expand(args)
     settings(expandedArgs) match {

--- a/check/src/main/scala/rsc/checkbase/ToolUtil.scala
+++ b/check/src/main/scala/rsc/checkbase/ToolUtil.scala
@@ -12,9 +12,7 @@ import scala.meta.io._
 import scala.util._
 
 trait ToolUtil extends CacheUtil with NscUtil {
-  def metacp(
-      dependencyClasspath: List[Path],
-      classpath: List[Path]): ToolResult[List[Path]] = {
+  def metacp(dependencyClasspath: List[Path], classpath: List[Path]): ToolResult[List[Path]] = {
     withConsole { console =>
       import scala.meta.metacp._
       val relative = Paths.get(metacpVersion).resolve("out")

--- a/check/src/main/scala/rsc/checkmjar/Checker.scala
+++ b/check/src/main/scala/rsc/checkmjar/Checker.scala
@@ -70,9 +70,7 @@ class Checker(nscResult: Path, rscResult: Path) extends CheckerBase {
 
   case class Index(sig: Scalasig, map: Map[String, EmbeddedSymbol])
 
-  private def load(
-      path: Path,
-      problem: String => Problem): Map[String, Index] = {
+  private def load(path: Path, problem: String => Problem): Map[String, Index] = {
     val scalasigs = mutable.Map[String, Index]()
     Scalasigs(path) {
       case ParsedScalasig(_, _, sig @ Scalasig(name, _, syms)) =>

--- a/check/src/main/scala/rsc/checkmjar/Settings.scala
+++ b/check/src/main/scala/rsc/checkmjar/Settings.scala
@@ -6,10 +6,7 @@ import java.io.File.pathSeparator
 import java.nio.file._
 import rsc.checkbase._
 
-final case class Settings(
-    cp: List[Path] = Nil,
-    ins: List[Path] = Nil,
-    quiet: Boolean = false)
+final case class Settings(cp: List[Path] = Nil, ins: List[Path] = Nil, quiet: Boolean = false)
     extends SettingsBase
 
 // FIXME: https://github.com/twitter/rsc/issues/166

--- a/check/src/main/scala/rsc/checkoutline/Checker.scala
+++ b/check/src/main/scala/rsc/checkoutline/Checker.scala
@@ -66,9 +66,7 @@ class Checker(nscResult: Path, rscResult: Path) extends CheckerBase {
     }
   }
 
-  case class Index(
-      infos: Map[String, SymbolInformation],
-      anchors: Map[String, String])
+  case class Index(infos: Map[String, SymbolInformation], anchors: Map[String, String])
 
   private def load(path: Path): Index = {
     val infos = mutable.Map[String, SymbolInformation]()
@@ -108,9 +106,7 @@ class Checker(nscResult: Path, rscResult: Path) extends CheckerBase {
     Index(infos1.map(info => info.symbol -> info).toMap, index.anchors)
   }
 
-  private def highlevelPatch(
-      index: Index,
-      info: SymbolInformation): SymbolInformation = {
+  private def highlevelPatch(index: Index, info: SymbolInformation): SymbolInformation = {
     val indexOps = new IndexOps(index)
     import indexOps._
     val stdlib = new rsc.semantics.Stdlib {}

--- a/check/src/main/scala/rsc/checkoutline/Settings.scala
+++ b/check/src/main/scala/rsc/checkoutline/Settings.scala
@@ -6,10 +6,7 @@ import java.io.File.pathSeparator
 import java.nio.file._
 import rsc.checkbase._
 
-final case class Settings(
-    cp: List[Path] = Nil,
-    ins: List[Path] = Nil,
-    quiet: Boolean = false)
+final case class Settings(cp: List[Path] = Nil, ins: List[Path] = Nil, quiet: Boolean = false)
     extends SettingsBase
 
 // FIXME: https://github.com/twitter/rsc/issues/166

--- a/check/src/main/scala/rsc/checkparse/Main.scala
+++ b/check/src/main/scala/rsc/checkparse/Main.scala
@@ -25,10 +25,7 @@ object Main extends MainBase[Settings, Path, NscGlobal#Tree, RscTree] {
     path.parseRsc()
   }
 
-  def checker(
-      settings: Settings,
-      nscResult: NscGlobal#Tree,
-      rscResult: RscTree) = {
+  def checker(settings: Settings, nscResult: NscGlobal#Tree, rscResult: RscTree) = {
     new Checker(nscGlobal, nscResult, rscResult)
   }
 

--- a/check/src/main/scala/rsc/checkparse/Settings.scala
+++ b/check/src/main/scala/rsc/checkparse/Settings.scala
@@ -5,8 +5,7 @@ package rsc.checkparse
 import java.nio.file._
 import rsc.checkbase._
 
-final case class Settings(ins: List[Path] = Nil, quiet: Boolean = false)
-    extends SettingsBase
+final case class Settings(ins: List[Path] = Nil, quiet: Boolean = false) extends SettingsBase
 
 // FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {

--- a/check/src/main/scala/rsc/diffmjar/Settings.scala
+++ b/check/src/main/scala/rsc/diffmjar/Settings.scala
@@ -6,10 +6,7 @@ import java.io.File.pathSeparator
 import java.nio.file._
 import rsc.checkbase._
 
-final case class Settings(
-    nscClasspath: List[Path],
-    rscClasspath: List[Path],
-    quiet: Boolean)
+final case class Settings(nscClasspath: List[Path], rscClasspath: List[Path], quiet: Boolean)
     extends SettingsBase
 
 // FIXME: https://github.com/twitter/rsc/issues/166

--- a/check/src/main/scala/rsc/diffoutline/Settings.scala
+++ b/check/src/main/scala/rsc/diffoutline/Settings.scala
@@ -6,10 +6,7 @@ import java.io.File.pathSeparator
 import java.nio.file._
 import rsc.checkbase._
 
-final case class Settings(
-    nscClasspath: List[Path],
-    rscClasspath: List[Path],
-    quiet: Boolean)
+final case class Settings(nscClasspath: List[Path], rscClasspath: List[Path], quiet: Boolean)
     extends SettingsBase
 
 // FIXME: https://github.com/twitter/rsc/issues/166

--- a/mjar/mjar/src/main/scala/scala/meta/internal/mjar/ConvertException.scala
+++ b/mjar/mjar/src/main/scala/scala/meta/internal/mjar/ConvertException.scala
@@ -5,8 +5,7 @@ package scala.meta.internal.mjar
 import java.io.File.pathSeparator
 import java.nio.file._
 
-case class ConvertException(message: String, cause: Throwable)
-    extends Exception(message, cause)
+case class ConvertException(message: String, cause: Throwable) extends Exception(message, cause)
 
 object ConvertException {
   def apply(in: List[Path], sym: String, cause: Throwable): ConvertException = {

--- a/mjar/mjar/src/main/scala/scala/meta/internal/mjar/Pickle.scala
+++ b/mjar/mjar/src/main/scala/scala/meta/internal/mjar/Pickle.scala
@@ -385,11 +385,11 @@ class Pickle(abi: Abi, symtab: Symtab, sroot1: String, sroot2: String) {
               TypeName(gensym.wildcardExistential())
             } else {
               sinfo.kind match {
-                case k.LOCAL | k.FIELD | k.METHOD | k.CONSTRUCTOR | k.MACRO |
-                    k.PARAMETER | k.SELF_PARAMETER =>
+                case k.LOCAL | k.FIELD | k.METHOD | k.CONSTRUCTOR | k.MACRO | k.PARAMETER |
+                    k.SELF_PARAMETER =>
                   TermName(ssym.desc.value.encode)
-                case k.TYPE | k.TYPE_PARAMETER | k.OBJECT | k.PACKAGE_OBJECT |
-                    k.CLASS | k.TRAIT | k.INTERFACE =>
+                case k.TYPE | k.TYPE_PARAMETER | k.OBJECT | k.PACKAGE_OBJECT | k.CLASS | k.TRAIT |
+                    k.INTERFACE =>
                   TypeName(ssym.desc.value.encode)
                 case _ =>
                   crash(sinfo.toProtoString)
@@ -571,8 +571,7 @@ class Pickle(abi: Abi, symtab: Symtab, sroot1: String, sroot2: String) {
       } else if (ssym.isTrait) {
         sinfo.signature match {
           case s.ClassSignature(_, _, _, ds) =>
-            ds.symbols.forall(sym =>
-              sym.isDeferred || sym.isAbstractType || sym.isAliasType)
+            ds.symbols.forall(sym => sym.isDeferred || sym.isAbstractType || sym.isAliasType)
           case _ =>
             false
         }

--- a/mjar/mjar/src/main/scala/scala/meta/internal/mjar/Util.scala
+++ b/mjar/mjar/src/main/scala/scala/meta/internal/mjar/Util.scala
@@ -5,8 +5,7 @@ package scala.meta.internal.mjar
 import scala.compat.Platform.EOL
 
 trait Util {
-  case class CrashException(message: String, cause: Throwable)
-      extends Exception(message, cause)
+  case class CrashException(message: String, cause: Throwable) extends Exception(message, cause)
 
   def crash(): Nothing = {
     crash(null, null)

--- a/mjar/mjar/src/main/scala/scala/meta/mjar/Settings.scala
+++ b/mjar/mjar/src/main/scala/scala/meta/mjar/Settings.scala
@@ -49,10 +49,7 @@ final class Settings private (
 // FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {
   def parse(args: List[String], reporter: Reporter): Option[Settings] = {
-    def loop(
-        settings: Settings,
-        allowOptions: Boolean,
-        args: List[String]): Option[Settings] = {
+    def loop(settings: Settings, allowOptions: Boolean, args: List[String]): Option[Settings] = {
       args match {
         case "--" +: rest =>
           loop(settings, false, rest)

--- a/mjar/scalap/src/main/scala/scala/meta/scalap/Settings.scala
+++ b/mjar/scalap/src/main/scala/scala/meta/scalap/Settings.scala
@@ -22,9 +22,7 @@ final class Settings private (
     copy(paths = paths)
   }
 
-  private def copy(
-      format: Format = format,
-      paths: List[Path] = paths): Settings = {
+  private def copy(format: Format = format, paths: List[Path] = paths): Settings = {
     new Settings(format = format, paths = paths)
   }
 }
@@ -32,10 +30,7 @@ final class Settings private (
 // FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {
   def parse(args: List[String], reporter: Reporter): Option[Settings] = {
-    def loop(
-        settings: Settings,
-        allowOptions: Boolean,
-        args: List[String]): Option[Settings] = {
+    def loop(settings: Settings, allowOptions: Boolean, args: List[String]): Option[Settings] = {
       args match {
         case "--" +: rest =>
           loop(settings, false, rest)

--- a/mjar/scalasig/src/main/scala/scala/meta/internal/scalasig/ClassfileCodec.scala
+++ b/mjar/scalasig/src/main/scala/scala/meta/internal/scalasig/ClassfileCodec.scala
@@ -48,13 +48,7 @@ object ClassfileCodec {
 
   def toBinary(classfile: Classfile): Array[Byte] = {
     val classWriter = new ClassWriter(0)
-    classWriter.visit(
-      V1_8,
-      ACC_PUBLIC + ACC_SUPER,
-      classfile.name,
-      null,
-      "java/lang/Object",
-      null)
+    classWriter.visit(V1_8, ACC_PUBLIC + ACC_SUPER, classfile.name, null, "java/lang/Object", null)
     if (classfile.source.nonEmpty) {
       classWriter.visitSource(classfile.source, null)
     }

--- a/mjar/scalasig/src/main/scala/scala/meta/internal/scalasig/DataPrettifiers.scala
+++ b/mjar/scalasig/src/main/scala/scala/meta/internal/scalasig/DataPrettifiers.scala
@@ -143,8 +143,7 @@ class HighlevelEntityPrettifier extends DataTransformer {
   }
 }
 
-class HighlevelScalasigPrettifier(sig: h.Scalasig)
-    extends HighlevelEntityPrettifier
+class HighlevelScalasigPrettifier(sig: h.Scalasig) extends HighlevelEntityPrettifier
 
 class LowlevelEntityPrettifier extends DataTransformer {
   override protected def apply(fields: List[Field]): List[Field] = {
@@ -215,8 +214,7 @@ class LowlevelEntityPrettifier extends DataTransformer {
   }
 }
 
-class LowlevelScalasigPrettifier(sig: l.Scalasig)
-    extends LowlevelEntityPrettifier {
+class LowlevelScalasigPrettifier(sig: l.Scalasig) extends LowlevelEntityPrettifier {
   override protected def apply(fields: List[Field]): List[Field] = {
     owner match {
       case entry: l.Entry =>

--- a/mjar/scalasig/src/main/scala/scala/meta/scalasig/Classfile.scala
+++ b/mjar/scalasig/src/main/scala/scala/meta/scalasig/Classfile.scala
@@ -4,10 +4,7 @@ package scala.meta.scalasig
 
 import scala.meta.internal.scalasig._
 
-case class Classfile(
-    name: String,
-    source: String,
-    scalasigBytes: Option[Array[Byte]]) {
+case class Classfile(name: String, source: String, scalasigBytes: Option[Array[Byte]]) {
   def toBinary: Array[Byte] = {
     try {
       ClassfileCodec.toBinary(this)

--- a/mjar/scalasig/src/main/scala/scala/meta/scalasig/Exceptions.scala
+++ b/mjar/scalasig/src/main/scala/scala/meta/scalasig/Exceptions.scala
@@ -5,8 +5,7 @@ package scala.meta.scalasig
 import scala.meta.scalasig.{highlevel => h}
 import scala.meta.scalasig.{lowlevel => l}
 
-case class ClassfileReadException(binary: Binary, cause: Throwable)
-    extends Exception {
+case class ClassfileReadException(binary: Binary, cause: Throwable) extends Exception {
   override def getMessage: String = {
     val details = s"${cause.getClass.getName}: ${cause.getMessage}"
     "failed to read classfile from ${binary}: $details"
@@ -14,8 +13,7 @@ case class ClassfileReadException(binary: Binary, cause: Throwable)
   setStackTrace(cause.getStackTrace)
 }
 
-case class ClassfileWriteException(classfile: Classfile, cause: Throwable)
-    extends Exception {
+case class ClassfileWriteException(classfile: Classfile, cause: Throwable) extends Exception {
   override def getMessage: String = {
     val details = s"${cause.getClass.getName}: ${cause.getMessage}"
     s"failed to write classfile ${classfile.name}: $details"
@@ -23,10 +21,7 @@ case class ClassfileWriteException(classfile: Classfile, cause: Throwable)
   setStackTrace(cause.getStackTrace)
 }
 
-case class ScalasigReadException(
-    binary: Binary,
-    classfile: Classfile,
-    cause: Throwable)
+case class ScalasigReadException(binary: Binary, classfile: Classfile, cause: Throwable)
     extends Exception {
   override def getMessage: String = {
     val where = binary match {
@@ -39,8 +34,7 @@ case class ScalasigReadException(
   setStackTrace(cause.getStackTrace)
 }
 
-case class ScalasigWriteException(scalasig: l.Scalasig, cause: Throwable)
-    extends Exception {
+case class ScalasigWriteException(scalasig: l.Scalasig, cause: Throwable) extends Exception {
   override def getMessage: String = {
     val details = s"${cause.getClass.getName}: ${cause.getMessage}"
     s"failed to write scalasig: $details"
@@ -48,8 +42,7 @@ case class ScalasigWriteException(scalasig: l.Scalasig, cause: Throwable)
   setStackTrace(cause.getStackTrace)
 }
 
-case class ScalasigConvertException(scalasig: Any, cause: Throwable)
-    extends Exception {
+case class ScalasigConvertException(scalasig: Any, cause: Throwable) extends Exception {
   override def getMessage: String = {
     val name = scalasig match {
       case h.Scalasig(name, _, _) => name

--- a/mjar/scalasig/src/main/scala/scala/meta/scalasig/Results.scala
+++ b/mjar/scalasig/src/main/scala/scala/meta/scalasig/Results.scala
@@ -16,13 +16,9 @@ package scalasig {
       with l.ScalasigResult
       with h.ScalasigResult
 
-  case class ParsedClassfile(binary: Binary, classfile: Classfile)
-      extends ClassfileResult
+  case class ParsedClassfile(binary: Binary, classfile: Classfile) extends ClassfileResult
 
-  case class FailedScalasig(
-      binary: Binary,
-      classfile: Classfile,
-      cause: Throwable)
+  case class FailedScalasig(binary: Binary, classfile: Classfile, cause: Throwable)
       extends l.ScalasigResult
       with h.ScalasigResult
 
@@ -36,10 +32,7 @@ package scalasig.highlevel {
     def binary: Binary
   }
 
-  case class ParsedScalasig(
-      binary: Binary,
-      classfile: Classfile,
-      scalasig: Scalasig)
+  case class ParsedScalasig(binary: Binary, classfile: Classfile, scalasig: Scalasig)
       extends ScalasigResult
 }
 
@@ -48,9 +41,6 @@ package scalasig.lowlevel {
     def binary: Binary
   }
 
-  case class ParsedScalasig(
-      binary: Binary,
-      classfile: Classfile,
-      scalasig: Scalasig)
+  case class ParsedScalasig(binary: Binary, classfile: Classfile, scalasig: Scalasig)
       extends ScalasigResult
 }

--- a/mjar/scalasig/src/main/scala/scala/meta/scalasig/highlevel/Scalasig.scala
+++ b/mjar/scalasig/src/main/scala/scala/meta/scalasig/highlevel/Scalasig.scala
@@ -6,8 +6,7 @@ import scala.meta.internal.scalasig._
 import scala.meta.scalasig._
 import scala.meta.scalasig.{lowlevel => l}
 
-case class Scalasig(name: String, source: String, symbols: List[EmbeddedSymbol])
-    extends Pretty {
+case class Scalasig(name: String, source: String, symbols: List[EmbeddedSymbol]) extends Pretty {
   def toLowlevel: l.Scalasig = {
     try {
       ScalasigLowlevel(this)

--- a/mjar/scalasig/src/main/scala/scala/meta/scalasig/lowlevel/Scalasig.scala
+++ b/mjar/scalasig/src/main/scala/scala/meta/scalasig/lowlevel/Scalasig.scala
@@ -6,8 +6,7 @@ import scala.meta.internal.scalasig._
 import scala.meta.scalasig._
 import scala.meta.scalasig.{highlevel => h}
 
-case class Scalasig(name: String, source: String, entries: Array[Entry])
-    extends Pretty {
+case class Scalasig(name: String, source: String, entries: Array[Entry]) extends Pretty {
   def toHighlevel: h.Scalasig = {
     try {
       ScalasigHighlevel(this)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -112,8 +112,7 @@ object Build extends AutoPlugin {
       )
       lazy val publish = command(projects.public.map(_ + "/publish"))
       lazy val publishLocal = command(projects.public.map(_ + "/publishLocal"))
-      lazy val publishSigned = command(
-        projects.public.map(_ + "/publishSigned"))
+      lazy val publishSigned = command(projects.public.map(_ + "/publishSigned"))
       lazy val compile = "tests/test:compile"
       lazy val fastTest = "tests/fast:test"
       lazy val slowTest = command("tests/slow:test")

--- a/rsc/src/main/scala/rsc/Compiler.scala
+++ b/rsc/src/main/scala/rsc/Compiler.scala
@@ -18,9 +18,7 @@ import rsc.settings._
 import rsc.syntax._
 import rsc.util._
 
-class Compiler(val settings: Settings, val reporter: Reporter)
-    extends Closeable
-    with Pretty {
+class Compiler(val settings: Settings, val reporter: Reporter) extends Closeable with Pretty {
   var trees: List[Source] = Nil
   var gensyms: Gensyms = Gensyms()
   var symtab: Symtab = Symtab(settings)

--- a/rsc/src/main/scala/rsc/lexis/Positions.scala
+++ b/rsc/src/main/scala/rsc/lexis/Positions.scala
@@ -4,10 +4,7 @@ package rsc.lexis
 
 import rsc.pretty._
 
-sealed class Position protected (
-    val input: Input,
-    val start: Offset,
-    val end: Offset)
+sealed class Position protected (val input: Input, val start: Offset, val end: Offset)
     extends Pretty {
   def startLine: Int = input.offsetToLine(start)
   def startColumn: Int = start - input.lineToOffset(startLine)

--- a/rsc/src/main/scala/rsc/outline/Outliner.scala
+++ b/rsc/src/main/scala/rsc/outline/Outliner.scala
@@ -9,11 +9,7 @@ import rsc.syntax._
 import rsc.util._
 
 // FIXME: https://github.com/twitter/rsc/issues/104
-final class Outliner private (
-    settings: Settings,
-    reporter: Reporter,
-    symtab: Symtab,
-    todo: Todo) {
+final class Outliner private (settings: Settings, reporter: Reporter, symtab: Symtab, todo: Todo) {
   def apply(env: Env, work: Work): Unit = {
     work match {
       case scope: Scope => apply(env, scope)
@@ -409,11 +405,7 @@ final class Outliner private (
 }
 
 object Outliner {
-  def apply(
-      settings: Settings,
-      reporter: Reporter,
-      symtab: Symtab,
-      todo: Todo): Outliner = {
+  def apply(settings: Settings, reporter: Reporter, symtab: Symtab, todo: Todo): Outliner = {
     new Outliner(settings, reporter, symtab, todo)
   }
 }

--- a/rsc/src/main/scala/rsc/outline/Scopes.scala
+++ b/rsc/src/main/scala/rsc/outline/Scopes.scala
@@ -306,8 +306,7 @@ final class PackageObjectScope private (
   }
 }
 
-class TemplateScope protected (sym: Symbol, val tree: DefnTemplate)
-    extends StorageScope(sym) {
+class TemplateScope protected (sym: Symbol, val tree: DefnTemplate) extends StorageScope(sym) {
   var _parents: List[Scope] = null
   var _self: List[Scope] = null
   var _env: Env = null

--- a/rsc/src/main/scala/rsc/outline/Synthesizer.scala
+++ b/rsc/src/main/scala/rsc/outline/Synthesizer.scala
@@ -60,10 +60,7 @@ final class Synthesizer private (
     defaultGetters(env, tree.tparams, tree)
   }
 
-  private def defaultGetters(
-      env: Env,
-      treeTparams: List[TypeParam],
-      tree: Parameterized): Unit = {
+  private def defaultGetters(env: Env, treeTparams: List[TypeParam], tree: Parameterized): Unit = {
     var paramPos = 0
     val treeParamss = tree.paramss
     treeParamss.zipWithIndex.foreach {

--- a/rsc/src/main/scala/rsc/parse/Defns.scala
+++ b/rsc/src/main/scala/rsc/parse/Defns.scala
@@ -149,8 +149,7 @@ trait Defns {
         case (pat0 @ PatId(value), _) =>
           val id = atPos(pat0.pos)(TermId(value))
           atPos(pat0.pos)(PatVar(id, None))
-        case (pat0 @ PatVar(id, pat0Tpt), i)
-            if i == pats0.length - 1 && tpt.isEmpty =>
+        case (pat0 @ PatVar(id, pat0Tpt), i) if i == pats0.length - 1 && tpt.isEmpty =>
           tpt = pat0Tpt
           atPos(pat0.pos)(PatVar(id, None))
         case (pat0, _) =>

--- a/rsc/src/main/scala/rsc/parse/Infix.scala
+++ b/rsc/src/main/scala/rsc/parse/Infix.scala
@@ -21,9 +21,7 @@ trait Infix {
     def op1 = opStack.head.operator.value
     if (opStack != base && op1.precedence == op2.precedence) {
       if (op1.isLeftAssoc != op2.isLeftAssoc) {
-        reportOffset(
-          opStack.head.offset,
-          MixedLeftAndRightAssociativeOps(_, op1, op2))
+        reportOffset(opStack.head.offset, MixedLeftAndRightAssociativeOps(_, op1, op2))
       }
     }
     def loop(top: Tree): Tree = {

--- a/rsc/src/main/scala/rsc/parse/Modifiers.scala
+++ b/rsc/src/main/scala/rsc/parse/Modifiers.scala
@@ -48,9 +48,7 @@ trait Modifiers {
     atPos(start)(Mods(annots(skipNewLines = false, exactlyOneArglist = false)))
   }
 
-  private def annots(
-      skipNewLines: Boolean,
-      exactlyOneArglist: Boolean): List[Mod] = {
+  private def annots(skipNewLines: Boolean, exactlyOneArglist: Boolean): List[Mod] = {
     if (skipNewLines) {
       newLineOpt()
     }

--- a/rsc/src/main/scala/rsc/parse/Parser.scala
+++ b/rsc/src/main/scala/rsc/parse/Parser.scala
@@ -34,11 +34,7 @@ final class Parser private (
     with Wildcards
 
 object Parser {
-  def apply(
-      settings: Settings,
-      reporter: Reporter,
-      gensym: Gensym,
-      input: Input): Parser = {
+  def apply(settings: Settings, reporter: Reporter, gensym: Gensym, input: Input): Parser = {
     new Parser(settings, reporter, gensym, input)
   }
 }

--- a/rsc/src/main/scala/rsc/parse/Terms.scala
+++ b/rsc/src/main/scala/rsc/parse/Terms.scala
@@ -313,10 +313,7 @@ trait Terms {
     simpleTermRest(start, unfinished, canApply = canApply)
   }
 
-  private def simpleTermRest(
-      start: Offset,
-      unfinished: Term,
-      canApply: Boolean): Term = {
+  private def simpleTermRest(start: Offset, unfinished: Term, canApply: Boolean): Term = {
     if (canApply) newLineOptWhenFollowedBy(LBRACE)
     in.token match {
       case DOT =>
@@ -344,10 +341,7 @@ trait Terms {
     }
   }
 
-  private def lambdaRest(
-      start: Offset,
-      unfinished: Term,
-      location: Location): TermFunction = {
+  private def lambdaRest(start: Offset, unfinished: Term, location: Location): TermFunction = {
     accept(ARROW)
     val unfinishedReinterpretedAsParams = {
       object ParamLike {

--- a/rsc/src/main/scala/rsc/pretty/Printer.scala
+++ b/rsc/src/main/scala/rsc/pretty/Printer.scala
@@ -41,8 +41,7 @@ class Printer {
     else str("null")
   }
 
-  def rep[T](pre: String, xs: Iterable[T], sep: String, suf: String)(
-      f: T => Unit): Unit = {
+  def rep[T](pre: String, xs: Iterable[T], sep: String, suf: String)(f: T => Unit): Unit = {
     if (xs.nonEmpty) {
       append(pre)
       rep(xs, sep)(f)

--- a/rsc/src/main/scala/rsc/report/Messages.scala
+++ b/rsc/src/main/scala/rsc/report/Messages.scala
@@ -19,8 +19,7 @@ sealed trait Message extends Pretty with Product {
 
 // ============ FUNDAMENTAL ============
 
-final case class CrashMessage(pos: Position, message: String, ex: Throwable)
-    extends Message {
+final case class CrashMessage(pos: Position, message: String, ex: Throwable) extends Message {
   def sev = FatalSeverity
   def text = {
     ex match {
@@ -114,20 +113,17 @@ final case class UnclosedString(pos: Position) extends Message {
 
 // ============ PARSER ============
 
-final case class ExpectedToken(pos: Position, expected: Token, actual: Token)
-    extends Message {
+final case class ExpectedToken(pos: Position, expected: Token, actual: Token) extends Message {
   def sev = FatalSeverity
   def text = s"${tokenStr(expected)} expected but ${tokenStr(actual)} found"
 }
 
-final case class ExpectedId(pos: Position, expected: String, actual: Token)
-    extends Message {
+final case class ExpectedId(pos: Position, expected: String, actual: Token) extends Message {
   def sev = FatalSeverity
   def text = "$expected expected but ${tokenStr(actual)} found"
 }
 
-final case class ExpectedClassOrObjectDefinition(pos: Position)
-    extends Message {
+final case class ExpectedClassOrObjectDefinition(pos: Position) extends Message {
   def sev = FatalSeverity
   def text = "expected class or object definition"
 }
@@ -204,10 +200,7 @@ final case class IllegalStartOfStatement(pos: Position) extends Message {
   def text = "illegal start of statement"
 }
 
-final case class MixedLeftAndRightAssociativeOps(
-    pos: Position,
-    op1: String,
-    op2: String)
+final case class MixedLeftAndRightAssociativeOps(pos: Position, op1: String, op2: String)
     extends Message {
   def sev = ErrorSeverity
   def text = {

--- a/rsc/src/main/scala/rsc/scan/History.scala
+++ b/rsc/src/main/scala/rsc/scan/History.scala
@@ -6,18 +6,7 @@ trait History {
   self: Scanner =>
 
   def snapshot(): Snapshot = {
-    Snapshot(
-      offset,
-      start,
-      end,
-      token,
-      value,
-      _mode,
-      _ilevels,
-      _ilevel,
-      _slevels,
-      _slevel,
-      _blevel)
+    Snapshot(offset, start, end, token, value, _mode, _ilevels, _ilevel, _slevels, _slevel, _blevel)
   }
 
   def restore(snapshot: Snapshot): Unit = {

--- a/rsc/src/main/scala/rsc/scan/Scanner.scala
+++ b/rsc/src/main/scala/rsc/scan/Scanner.scala
@@ -9,10 +9,7 @@ import rsc.settings._
 import rsc.util._
 import scala.annotation.switch
 
-final class Scanner private (
-    val settings: Settings,
-    val reporter: Reporter,
-    val input: Input)
+final class Scanner private (val settings: Settings, val reporter: Reporter, val input: Input)
     extends Characters
     with History
     with Messages
@@ -242,11 +239,10 @@ final class Scanner private (
         whitespace()
       case CR | LF | FF =>
         newline()
-      case 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' |
-          'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' |
-          'W' | 'X' | 'Y' | 'Z' | '$' | '_' | 'a' | 'b' | 'c' | 'd' | 'e' |
-          'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' |
-          'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z' =>
+      case 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' |
+          'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z' | '$' | '_' | 'a' | 'b' |
+          'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' |
+          'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z' =>
         alphanumericIdOrKeyword()
       case '<' =>
         def xmlPre = token == WHITESPACE || token == LPAREN || token == LBRACE
@@ -256,8 +252,8 @@ final class Scanner private (
         } else {
           symbolicIdOrKeyword()
         }
-      case '~' | '!' | '@' | '#' | '%' | '^' | '*' | '+' | '-' | '>' | '?' |
-          ':' | '=' | '&' | '|' | '\\' | '⇒' | '←' =>
+      case '~' | '!' | '@' | '#' | '%' | '^' | '*' | '+' | '-' | '>' | '?' | ':' | '=' | '&' | '|' |
+          '\\' | '⇒' | '←' =>
         symbolicIdOrKeyword()
       case '`' =>
         backquotedId()

--- a/rsc/src/main/scala/rsc/semanticdb/Semanticdb.scala
+++ b/rsc/src/main/scala/rsc/semanticdb/Semanticdb.scala
@@ -299,8 +299,8 @@ final class Semanticdb private (
 
     def access: s.Access = {
       kind match {
-        case k.LOCAL | k.PARAMETER | k.SELF_PARAMETER | k.TYPE_PARAMETER |
-            k.PACKAGE | k.PACKAGE_OBJECT =>
+        case k.LOCAL | k.PARAMETER | k.SELF_PARAMETER | k.TYPE_PARAMETER | k.PACKAGE |
+            k.PACKAGE_OBJECT =>
           s.NoAccess
         case _ =>
           outline match {

--- a/rsc/src/main/scala/rsc/settings/Settings.scala
+++ b/rsc/src/main/scala/rsc/settings/Settings.scala
@@ -18,10 +18,7 @@ final case class Settings(
 // FIXME: https://github.com/twitter/rsc/issues/166
 object Settings {
   def parse(args: List[String]): Option[Settings] = {
-    def loop(
-        settings: Settings,
-        allowOptions: Boolean,
-        args: List[String]): Option[Settings] = {
+    def loop(settings: Settings, allowOptions: Boolean, args: List[String]): Option[Settings] = {
       args match {
         case "--" +: rest =>
           loop(settings, false, rest)

--- a/rsc/src/main/scala/rsc/syntax/Trees.scala
+++ b/rsc/src/main/scala/rsc/syntax/Trees.scala
@@ -20,8 +20,7 @@ sealed trait Tree extends Pretty with Product {
 
 final case class AnonId() extends Id
 
-final case class Case(pat: Pat, cond: Option[Term], stats: List[Stat])
-    extends Tree
+final case class Case(pat: Pat, cond: Option[Term], stats: List[Stat]) extends Tree
 
 final case class CtorId() extends NamedId {
   def value = CtorId.value
@@ -57,11 +56,7 @@ sealed trait DefnDef extends Stat with Parameterized with TermOutline {
 
 sealed trait DefnCtor extends DefnDef
 
-final case class DefnField(
-    mods: Mods,
-    id: TermId,
-    tpt: Option[Tpt],
-    rhs: Option[Term])
+final case class DefnField(mods: Mods, id: TermId, tpt: Option[Tpt], rhs: Option[Term])
     extends Stat
     with TermOutline
 
@@ -98,9 +93,7 @@ final case class DefnObject(
   def paramss = Nil
 }
 
-final case class DefnPackage(pid: TermPath, stats: List[Stat])
-    extends Stat
-    with TermOutline {
+final case class DefnPackage(pid: TermPath, stats: List[Stat]) extends Stat with TermOutline {
   def mods = Mods(Nil)
   def id = pid.id.asInstanceOf[NamedId]
 }
@@ -118,11 +111,7 @@ final case class DefnPackageObject(
   def paramss = Nil
 }
 
-final case class DefnPat(
-    mods: Mods,
-    pats: List[Pat],
-    tpt: Option[Tpt],
-    rhs: Option[Term])
+final case class DefnPat(mods: Mods, pats: List[Pat], tpt: Option[Tpt], rhs: Option[Term])
     extends Stat
 
 final case class DefnProcedure(
@@ -201,8 +190,7 @@ final case class ImporteeUnimport(id: SomeId) extends Importee
 
 final case class ImporteeWildcard() extends Importee
 
-final case class Importer(qual: TermPath, importees: List[Importee])
-    extends Tree
+final case class Importer(qual: TermPath, importees: List[Importee]) extends Tree
 
 final case class Init(tpt: Tpt, argss: List[List[Term]]) extends Term {
   val id = CtorId()
@@ -311,8 +299,7 @@ final case class PatAlternative(pats: List[Pat]) extends Pat
 
 final case class PatBind(pats: List[Pat]) extends Pat
 
-final case class PatExtract(fun: TermPath, targs: List[Tpt], args: List[Pat])
-    extends Pat
+final case class PatExtract(fun: TermPath, targs: List[Tpt], args: List[Pat]) extends Pat
 
 final case class PatExtractInfix(lhs: Pat, op: TermId, rhs: Pat) extends Pat
 
@@ -320,11 +307,7 @@ final case class PatId(value: String) extends Pat with NamedId {
   def name = TermName(value)
 }
 
-final case class PatInterpolate(
-    id: TermId,
-    parts: List[PatLit],
-    args: List[Pat])
-    extends Pat
+final case class PatInterpolate(id: TermId, parts: List[PatLit], args: List[Pat]) extends Pat
 
 final case class PatLit(value: Any) extends Pat
 
@@ -353,11 +336,7 @@ final case class PrimaryCtor(mods: Mods, paramss: List[List[Param]])
   def ret = Some(TptId("Unit").withSym(UnitClass))
 }
 
-final case class SecondaryCtor(
-    mods: Mods,
-    id: CtorId,
-    paramss: List[List[Param]],
-    rhs: Term)
+final case class SecondaryCtor(mods: Mods, id: CtorId, paramss: List[List[Param]], rhs: Term)
     extends DefnCtor
     with TermOutline {
   def tparams = Nil
@@ -382,11 +361,7 @@ final case class TermAnnotate(fun: Term, mods: Mods) extends Term
 
 final case class TermApply(fun: Term, args: List[Term]) extends Term
 
-final case class TermApplyInfix(
-    lhs: Term,
-    op: TermId,
-    targs: List[Tpt],
-    args: List[Term])
+final case class TermApplyInfix(lhs: Term, op: TermId, targs: List[Tpt], args: List[Term])
     extends Term
 
 final case class TermApplyPostfix(arg: Term, op: TermId) extends Term
@@ -415,14 +390,9 @@ final case class TermId(value: String) extends TermPath with NamedId {
   def name = TermName(value)
 }
 
-final case class TermIf(cond: Term, thenp: Term, elsep: Option[Term])
-    extends Term
+final case class TermIf(cond: Term, thenp: Term, elsep: Option[Term]) extends Term
 
-final case class TermInterpolate(
-    id: TermId,
-    parts: List[TermLit],
-    args: List[Term])
-    extends Term
+final case class TermInterpolate(id: TermId, parts: List[TermLit], args: List[Term]) extends Term
 
 final case class TermLit(value: Any) extends Term
 
@@ -461,14 +431,9 @@ final case class TermThis(qual: Id) extends TermPath {
 
 final case class TermThrow(term: Term) extends Term
 
-final case class TermTry(term: Term, catchp: List[Case], finallyp: Option[Term])
-    extends Term
+final case class TermTry(term: Term, catchp: List[Case], finallyp: Option[Term]) extends Term
 
-final case class TermTryWithHandler(
-    term: Term,
-    catchp: Term,
-    finallyp: Option[Term])
-    extends Term
+final case class TermTryWithHandler(term: Term, catchp: Term, finallyp: Option[Term]) extends Term
 
 final case class TermTuple(args: List[Term]) extends Term
 
@@ -478,8 +443,7 @@ final case class TermWildcard() extends Term {
   val id = AnonId()
 }
 
-final case class TermWildcardFunction(ids: List[AnonId], body: Term)
-    extends Term
+final case class TermWildcardFunction(ids: List[AnonId], body: Term) extends Term
 
 // FIXME: https://github.com/twitter/rsc/issues/81
 final case class TermXml(raw: String) extends Term
@@ -518,8 +482,7 @@ sealed trait TptPath extends Tpt with Path
 
 final case class TptParameterize(fun: Tpt, targs: List[Tpt]) extends TptApply
 
-final case class TptParameterizeInfix(lhs: Tpt, op: TptId, rhs: Tpt)
-    extends TptApply {
+final case class TptParameterizeInfix(lhs: Tpt, op: TptId, rhs: Tpt) extends TptApply {
   def fun = op
   def targs = List(lhs, rhs)
 }
@@ -543,8 +506,7 @@ final case class TptTuple(targs: List[Tpt]) extends TptApply {
   }
 }
 
-final case class TptWildcard(lbound: Option[Tpt], ubound: Option[Tpt])
-    extends Tpt {
+final case class TptWildcard(lbound: Option[Tpt], ubound: Option[Tpt]) extends Tpt {
   val id = AnonId()
   def lo = lbound.getOrElse(TptId("Nothing").withSym(NothingClass))
   def hi = ubound.getOrElse(TptId("Any").withSym(AnyClass))

--- a/rsc/src/main/scala/rsc/util/CharUtil.scala
+++ b/rsc/src/main/scala/rsc/util/CharUtil.scala
@@ -35,8 +35,8 @@ trait CharUtil {
 
   def isSymbolicIdPart(ch: Char): Boolean = {
     (ch: @switch) match {
-      case '~' | '!' | '@' | '#' | '%' | '^' | '*' | '+' | '-' | '<' | '>' |
-          '?' | ':' | '=' | '&' | '|' | '\\' | '/' =>
+      case '~' | '!' | '@' | '#' | '%' | '^' | '*' | '+' | '-' | '<' | '>' | '?' | ':' | '=' | '&' |
+          '|' | '\\' | '/' =>
         true
       case _ =>
         val chtpe = Character.getType(ch)

--- a/rsc/src/main/scala/rsc/util/CrashException.scala
+++ b/rsc/src/main/scala/rsc/util/CrashException.scala
@@ -4,10 +4,7 @@ package rsc.util
 
 import rsc.lexis._
 
-final case class CrashException(
-    pos: Position,
-    message: String,
-    cause: Throwable)
+final case class CrashException(pos: Position, message: String, cause: Throwable)
     extends Exception(message, cause)
 
 object CrashException {

--- a/scalafix/rules/src/main/scala/rsc/rules/RscCompat.scala
+++ b/scalafix/rules/src/main/scala/rsc/rules/RscCompat.scala
@@ -114,12 +114,10 @@ case class RscCompat(legacyIndex: SemanticdbIndex, config: RscCompatConfig)
           case _ =>
             val info = index.symbols(symbol)
             target.body match {
-              case Term.ApplyType(Term.Name("implicitly"), _)
-                  if info.isImplicit =>
+              case Term.ApplyType(Term.Name("implicitly"), _) if info.isImplicit =>
                 return Patch.empty
-              case Term.ApplyType(
-                  Term.Select(Term.Name("Bijection"), Term.Name("connect")),
-                  _) if info.isImplicit =>
+              case Term.ApplyType(Term.Select(Term.Name("Bijection"), Term.Name("connect")), _)
+                  if info.isImplicit =>
                 return Patch.empty
               case _ =>
                 val returnType = info.signature match {

--- a/scalafix/rules/src/main/scala/rsc/rules/pretty/SemanticdbPrinter.scala
+++ b/scalafix/rules/src/main/scala/rsc/rules/pretty/SemanticdbPrinter.scala
@@ -71,9 +71,7 @@ class SemanticdbPrinter(env: Env, index: DocumentIndex) extends Printer {
       str("}")
     case s.MacroExpansionTree(expandee, _) =>
       expandee match {
-        case s.ApplyTree(
-            s.IdTree("scala/reflect/package.materializeClassTag()."),
-            Nil) =>
+        case s.ApplyTree(s.IdTree("scala/reflect/package.materializeClassTag()."), Nil) =>
           str("_root_.scala.reflect.`package`.classTag")
         case _ =>
           pprint(expandee)
@@ -160,8 +158,8 @@ class SemanticdbPrinter(env: Env, index: DocumentIndex) extends Printer {
         case s.RepeatedType(utpe) =>
           opt(utpe)(normal)
           str("*")
-        case _: s.SuperType | _: s.ConstantType | _: s.IntersectionType |
-            _: s.UnionType | s.NoType =>
+        case _: s.SuperType | _: s.ConstantType | _: s.IntersectionType | _: s.UnionType |
+            s.NoType =>
           val details = tpe.asMessage.toProtoString
           sys.error(s"unsupported type: $details")
       }

--- a/tests/src/main/scala/rsc/tests/RscTests.scala
+++ b/tests/src/main/scala/rsc/tests/RscTests.scala
@@ -25,11 +25,7 @@ trait RscTests extends FunSuite with FileFixtures with DiffUtil with ToolUtil {
     }
   }
 
-  def assertEquals(
-      h1: String,
-      b1: Array[Byte],
-      h2: String,
-      b2: Array[Byte]): Unit = {
+  def assertEquals(h1: String, b1: Array[Byte], h2: String, b2: Array[Byte]): Unit = {
     val xxd1 = xxd(b1).right.get
     val xxd2 = xxd(b2).right.get
     if (xxd1 != xxd2) {

--- a/tests/src/test/scala/rsc/tests/ScalasigTests.scala
+++ b/tests/src/test/scala/rsc/tests/ScalasigTests.scala
@@ -24,28 +24,16 @@ class ScalasigTests extends RscTests {
             val scalasigBytes1 = classfile1.scalasigBytes.get
             val classfile2 = scalasig1.toClassfile
             val scalasigBytes2 = classfile2.scalasigBytes.get
-            assertEquals(
-              "scalasigBytes1",
-              scalasigBytes1,
-              "scalasigBytes2",
-              scalasigBytes2)
+            assertEquals("scalasigBytes1", scalasigBytes1, "scalasigBytes2", scalasigBytes2)
             Scalasig.fromClassfile(classfile2) match {
               case ParsedScalasig(_, _, scalasig2) =>
                 val scalasigStr1 = scalasig1.toHighlevel.toString
                 val scalasigStr2 = scalasig2.toHighlevel.toString
-                assertEquals(
-                  "scalasig1",
-                  scalasigStr1,
-                  "scalasig2",
-                  scalasigStr2)
+                assertEquals("scalasig1", scalasigStr1, "scalasig2", scalasigStr2)
                 val classfile3 = scalasig2.toClassfile
                 val classfileBytes2 = classfile2.toBinary
                 val classfileBytes3 = classfile3.toBinary
-                assertEquals(
-                  "classfileBytes2",
-                  classfileBytes2,
-                  "classfileBytes3",
-                  classfileBytes3)
+                assertEquals("classfileBytes2", classfileBytes2, "classfileBytes3", classfileBytes3)
               case EmptyScalasig(_, _) =>
                 fail(s"failed to parse classfile2: ${classfile2.dump()}")
               case FailedScalasig(_, _, cause) =>


### PR DESCRIPTION
I have to admit that the maxColumn=80 experiment has failed.
Oftentimes, it is too restrictive and, as a result, every now and then
it forces creation of useless temporary variables.

maxColumn=100 that we're using in Scalameta is much more flexible
without major downsides.

One minor downside is that 100 columns doesn't allow Sublime Text to
horizontally fit a sidebar and two text buffers with the font size
I'm accustomed to. However, I've been working like that in Scalameta,
and it wasn't too much of a problem.