### PR TITLE
Fix crash when extending type aliases

### DIFF
--- a/bench/src/main/scala/rsc/bench/RscIndex.scala
+++ b/bench/src/main/scala/rsc/bench/RscIndex.scala
@@ -8,8 +8,8 @@ import org.openjdk.jmh.annotations.Mode._
 
 @BenchmarkMode(Array(SampleTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 1, jvmArgs = Array("-Xms4G", "-Xmx4G"))
 class RscIndex extends RscBenchmark {
   @Benchmark

--- a/bench/src/main/scala/rsc/bench/RscOutline.scala
+++ b/bench/src/main/scala/rsc/bench/RscOutline.scala
@@ -8,8 +8,8 @@ import org.openjdk.jmh.annotations.Mode._
 
 @BenchmarkMode(Array(SampleTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 1, jvmArgs = Array("-Xms4G", "-Xmx4G"))
 class RscOutline extends RscBenchmark {
   @Benchmark

--- a/bench/src/main/scala/rsc/bench/RscParse.scala
+++ b/bench/src/main/scala/rsc/bench/RscParse.scala
@@ -8,8 +8,8 @@ import org.openjdk.jmh.annotations.Mode._
 
 @BenchmarkMode(Array(SampleTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 1, jvmArgs = Array("-Xms4G", "-Xmx4G"))
 class RscParse extends RscBenchmark {
   @Benchmark

--- a/bench/src/main/scala/rsc/bench/RscScalasig.scala
+++ b/bench/src/main/scala/rsc/bench/RscScalasig.scala
@@ -9,8 +9,8 @@ import org.openjdk.jmh.annotations.Mode._
 
 @BenchmarkMode(Array(SampleTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 1, jvmArgs = Array("-Xms4G", "-Xmx4G"))
 class RscScalasig extends RscBenchmark {
   @Benchmark

--- a/bench/src/main/scala/rsc/bench/RscSemanticdb.scala
+++ b/bench/src/main/scala/rsc/bench/RscSemanticdb.scala
@@ -9,8 +9,8 @@ import org.openjdk.jmh.annotations.Mode._
 
 @BenchmarkMode(Array(SampleTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 1, jvmArgs = Array("-Xms4G", "-Xmx4G"))
 class RscSemanticdb extends RscBenchmark {
   @Benchmark

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -241,10 +241,10 @@ is stored in `Symtab.outlines`.
 Signatures of classpath symbols are represented by SemanticDB data structures.
 Check out [the SemanticDB specification](https://github.com/scalameta/scalameta/blob/master/semanticdb/semanticdb3/semanticdb3.md)
 to learn more about supported languages and their metadata. SemanticDB payloads can be loaded
-from classpath via `Symtab.index`.
+from classpath via `Classpath.apply`.
 
 ```scala
-final class Index private (entries: HashMap[Symbol, Entry]) extends AutoCloseable {
+final class Classpath private (entries: HashMap[Symbol, Entry]) extends AutoCloseable {
   private val infos = new HashMap[Symbol, s.SymbolInformation]
 
   def contains(sym: Symbol): Boolean = {

--- a/examples/semantic/src/main/scala/267.scala
+++ b/examples/semantic/src/main/scala/267.scala
@@ -1,0 +1,7 @@
+package ticket267
+
+object M {
+  type X = Int => Int
+}
+
+abstract class C extends M.X

--- a/rsc/src/main/scala/rsc/Compiler.scala
+++ b/rsc/src/main/scala/rsc/Compiler.scala
@@ -172,7 +172,7 @@ class Compiler(val settings: Settings, val reporter: Reporter) extends AutoClose
   }
 
   def close(): Unit = {
-    symtab.close()
+    classpath.close()
     output.close()
   }
 

--- a/rsc/src/main/scala/rsc/Compiler.scala
+++ b/rsc/src/main/scala/rsc/Compiler.scala
@@ -97,12 +97,12 @@ class Compiler(val settings: Settings, val reporter: Reporter) extends AutoClose
   }
 
   private def index(): Unit = {
-    val indexer = Indexer(settings, reporter, symtab, todo)
+    val indexer = Indexer(settings, reporter, classpath, symtab, todo)
     indexer.apply()
   }
 
   private def schedule(): Unit = {
-    val scheduler = Scheduler(settings, reporter, gensyms, symtab, todo)
+    val scheduler = Scheduler(settings, reporter, gensyms, classpath, symtab, todo)
     trees.foreach { tree =>
       val env = Env(Nil, tree.lang)
       scheduler.apply(env, tree)
@@ -110,7 +110,7 @@ class Compiler(val settings: Settings, val reporter: Reporter) extends AutoClose
   }
 
   private def outline(): Unit = {
-    val outliner = Outliner(settings, reporter, gensyms, symtab, todo)
+    val outliner = Outliner(settings, reporter, gensyms, classpath, symtab, todo)
     while (!todo.isEmpty) {
       val (env, work) = todo.remove()
       try {

--- a/rsc/src/main/scala/rsc/outline/Env.scala
+++ b/rsc/src/main/scala/rsc/outline/Env.scala
@@ -10,10 +10,10 @@ import rsc.util._
 import scala.annotation.tailrec
 
 sealed class Env protected (val scopes: List[Scope], val lang: Language) extends Pretty {
-  def owner: SourceScope = {
-    def loop(scopes: List[Scope]): SourceScope = {
+  def owner: OutlineScope = {
+    def loop(scopes: List[Scope]): OutlineScope = {
       scopes match {
-        case (head: SourceScope) :: _ => head
+        case (head: OutlineScope) :: _ => head
         case head :: tail => loop(tail)
         case Nil => crash(this)
       }

--- a/rsc/src/main/scala/rsc/outline/Indexer.scala
+++ b/rsc/src/main/scala/rsc/outline/Indexer.scala
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.outline
 
+import rsc.classpath._
 import rsc.input._
 import rsc.report._
 import rsc.semantics._
@@ -9,12 +10,17 @@ import rsc.settings._
 import rsc.symtab._
 import rsc.util._
 
-final class Indexer private (settings: Settings, reporter: Reporter, symtab: Symtab, todo: Todo) {
+final class Indexer private (
+    settings: Settings,
+    reporter: Reporter,
+    classpath: Classpath,
+    symtab: Symtab,
+    todo: Todo) {
   def apply(): Unit = {
-    val rootScope = PackageScope(RootPackage, symtab)
+    val rootScope = PackageScope(RootPackage, classpath)
     symtab.scopes.put(rootScope.sym, rootScope)
     todo.add(Env(Nil, ScalaLanguage), rootScope)
-    val emptyScope = PackageScope(EmptyPackage, symtab)
+    val emptyScope = PackageScope(EmptyPackage, classpath)
     symtab.scopes.put(emptyScope.sym, emptyScope)
     todo.add(Env(Nil, ScalaLanguage), emptyScope)
 
@@ -43,7 +49,12 @@ final class Indexer private (settings: Settings, reporter: Reporter, symtab: Sym
 }
 
 object Indexer {
-  def apply(settings: Settings, reporter: Reporter, symtab: Symtab, todo: Todo): Indexer = {
-    new Indexer(settings, reporter, symtab, todo)
+  def apply(
+      settings: Settings,
+      reporter: Reporter,
+      classpath: Classpath,
+      symtab: Symtab,
+      todo: Todo): Indexer = {
+    new Indexer(settings, reporter, classpath, symtab, todo)
   }
 }

--- a/rsc/src/main/scala/rsc/outline/Indexer.scala
+++ b/rsc/src/main/scala/rsc/outline/Indexer.scala
@@ -11,10 +11,10 @@ import rsc.util._
 
 final class Indexer private (settings: Settings, reporter: Reporter, symtab: Symtab, todo: Todo) {
   def apply(): Unit = {
-    val rootScope = PackageScope(RootPackage, symtab.classpath)
+    val rootScope = PackageScope(RootPackage, symtab)
     symtab.scopes.put(rootScope.sym, rootScope)
     todo.add(Env(Nil, ScalaLanguage), rootScope)
-    val emptyScope = PackageScope(EmptyPackage, symtab.classpath)
+    val emptyScope = PackageScope(EmptyPackage, symtab)
     symtab.scopes.put(emptyScope.sym, emptyScope)
     todo.add(Env(Nil, ScalaLanguage), emptyScope)
 

--- a/rsc/src/main/scala/rsc/outline/Outliner.scala
+++ b/rsc/src/main/scala/rsc/outline/Outliner.scala
@@ -12,6 +12,7 @@ import rsc.symtab._
 import rsc.syntax._
 import rsc.util._
 import scala.collection.mutable
+import scala.meta.internal.{semanticdb => s}
 
 final class Outliner private (
     settings: Settings,
@@ -442,12 +443,90 @@ final class Outliner private (
       case resolution: FailedResolution =>
         resolution
       case ResolvedSymbol(sym) =>
-        symtab.scopify(sym)
+        scopify(sym)
+    }
+  }
+
+  private def scopify(sym: Symbol): ScopeResolution = {
+    if (symtab.scopes.contains(sym)) {
+      ResolvedScope(symtab.scopes(sym))
+    } else {
+      symtab.metadata(sym) match {
+        case OutlineMetadata(outline) =>
+          def loop(tpt: Tpt): ScopeResolution = {
+            tpt match {
+              case TptArray(_) =>
+                loop(TptId("Array").withSym(ArrayClass))
+              case TptApply(fun, _) =>
+                loop(fun)
+              case tpt: TptPath =>
+                tpt.id.sym match {
+                  case NoSymbol =>
+                    BlockedResolution(Unknown())
+                  case sym =>
+                    scopify(sym)
+                }
+              case TptWildcardExistential(_, tpt) =>
+                loop(tpt)
+              case _ =>
+                crash(tpt)
+            }
+          }
+          outline match {
+            case DefnMethod(mods, _, _, _, Some(tpt), _) if mods.hasVal => loop(tpt)
+            case outline: DefnType => loop(outline.desugaredUbound)
+            case outline: TypeParam => loop(outline.desugaredUbound)
+            case Param(_, _, Some(tpt), _) => loop(tpt)
+            case Self(_, Some(tpt)) => loop(tpt)
+            case outline @ Self(_, None) => loop(symtab.desugars.rets(outline))
+            case null => crash(sym)
+            case _ => crash(outline)
+          }
+        case ClasspathMetadata(info) =>
+          def loop(tpe: s.Type): Symbol = {
+            tpe match {
+              case s.TypeRef(_, sym, _) => sym
+              case s.SingleType(_, sym) => sym
+              case _ => crash(tpe.asMessage.toProtoString)
+            }
+          }
+          val scopeSym = {
+            if (sym == "scala/collection/convert/package.wrapAsScala.") {
+              // FIXME: https://github.com/twitter/rsc/issues/285
+              "scala/collection/convert/WrapAsScala#"
+            } else {
+              info.signature match {
+                case s.NoSignature if info.isPackage => sym
+                case _: s.ClassSignature => sym
+                case sig: s.MethodSignature if info.isVal => loop(sig.returnType)
+                case sig: s.TypeSignature => loop(sig.upperBound)
+                case sig: s.ValueSignature => loop(sig.tpe)
+                case sig => crash(info.toProtoString)
+              }
+            }
+          }
+          val scope = SignatureScope(scopeSym, classpath)
+          scope.succeed()
+          ResolvedScope(scope)
+        case NoMetadata =>
+          MissingResolution
+      }
     }
   }
 
   private implicit class EnvOutlinerOps(env: Env) {
     def isSynthetic: Boolean = env.scopes.length == 1
+  }
+
+  private implicit class BoundedScopifyOps(bounded: Bounded) {
+    def desugaredUbound: Tpt = {
+      bounded.lang match {
+        case ScalaLanguage | UnknownLanguage =>
+          bounded.ubound.getOrElse(TptId("Any").withSym(AnyClass))
+        case JavaLanguage =>
+          bounded.ubound.getOrElse(TptId("Object").withSym(ObjectClass))
+      }
+    }
   }
 }
 

--- a/rsc/src/main/scala/rsc/outline/Outliner.scala
+++ b/rsc/src/main/scala/rsc/outline/Outliner.scala
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.outline
 
+import rsc.classpath._
 import rsc.gensym._
 import rsc.input._
 import rsc.report._
@@ -16,10 +17,11 @@ final class Outliner private (
     settings: Settings,
     reporter: Reporter,
     gensyms: Gensyms,
+    classpath: Classpath,
     symtab: Symtab,
     todo: Todo) {
   private lazy val scheduler: Scheduler = {
-    Scheduler(settings, reporter, gensyms, symtab, todo)
+    Scheduler(settings, reporter, gensyms, classpath, symtab, todo)
   }
 
   def apply(env: Env, work: Work): Unit = {
@@ -454,8 +456,9 @@ object Outliner {
       settings: Settings,
       reporter: Reporter,
       gensyms: Gensyms,
+      classpath: Classpath,
       symtab: Symtab,
       todo: Todo): Outliner = {
-    new Outliner(settings, reporter, gensyms, symtab, todo)
+    new Outliner(settings, reporter, gensyms, classpath, symtab, todo)
   }
 }

--- a/rsc/src/main/scala/rsc/outline/Scheduler.scala
+++ b/rsc/src/main/scala/rsc/outline/Scheduler.scala
@@ -232,8 +232,7 @@ final class Scheduler private (
         }
         existingScope
       } else {
-        val rootScope = symtab.scopes(RootPackage).asInstanceOf[PackageScope]
-        val newScope = PackageScope(tree.id.sym, symtab.classpath)
+        val newScope = PackageScope(tree.id.sym, symtab)
         symtab.scopes.put(tree.id.sym, newScope)
         todo.add(env, newScope)
         newScope

--- a/rsc/src/main/scala/rsc/outline/Scheduler.scala
+++ b/rsc/src/main/scala/rsc/outline/Scheduler.scala
@@ -3,6 +3,7 @@
 package rsc.outline
 
 import java.util.LinkedHashSet
+import rsc.classpath._
 import rsc.gensym._
 import rsc.input._
 import rsc.report._
@@ -17,10 +18,11 @@ final class Scheduler private (
     settings: Settings,
     reporter: Reporter,
     gensyms: Gensyms,
+    classpath: Classpath,
     symtab: Symtab,
     todo: Todo) {
   private lazy val synthesizer: Synthesizer = {
-    Synthesizer(settings, reporter, gensyms, symtab, todo)
+    Synthesizer(settings, reporter, gensyms, classpath, symtab, todo)
   }
 
   def apply(env: Env, tree: Tree): Env = {
@@ -232,7 +234,7 @@ final class Scheduler private (
         }
         existingScope
       } else {
-        val newScope = PackageScope(tree.id.sym, symtab)
+        val newScope = PackageScope(tree.id.sym, classpath)
         symtab.scopes.put(tree.id.sym, newScope)
         todo.add(env, newScope)
         newScope
@@ -584,8 +586,9 @@ object Scheduler {
       settings: Settings,
       reporter: Reporter,
       gensyms: Gensyms,
+      classpath: Classpath,
       symtab: Symtab,
       todo: Todo): Scheduler = {
-    new Scheduler(settings, reporter, gensyms, symtab, todo)
+    new Scheduler(settings, reporter, gensyms, classpath, symtab, todo)
   }
 }

--- a/rsc/src/main/scala/rsc/outline/Scopes.scala
+++ b/rsc/src/main/scala/rsc/outline/Scopes.scala
@@ -123,7 +123,7 @@ sealed trait BinaryScope extends Scope {
   }
 }
 
-sealed abstract class SourceScope(sym: Symbol) extends Scope(sym) {
+sealed abstract class OutlineScope(sym: Symbol) extends Scope(sym) {
   private val impl: Map[Name, Symbol] = new LinkedHashMap[Name, Symbol]
 
   def decls: List[Symbol] = {
@@ -197,7 +197,7 @@ object ClasspathScope {
 }
 
 final class PackageScope private (sym: Symbol, val classpath: Classpath)
-    extends SourceScope(sym)
+    extends OutlineScope(sym)
     with BinaryScope {
   override def resolve(name: Name): SymbolResolution = {
     super.resolve(name) match {
@@ -225,7 +225,7 @@ object PackageScope {
   }
 }
 
-// ============ SOURCE SCOPES ============
+// ============ OUTLINE SCOPES ============
 
 final class ImporterScope private (val tree: Importer) extends Scope(NoSymbol) {
   var _parent1: Scope = null
@@ -361,7 +361,7 @@ object PackageObjectScope {
   }
 }
 
-final class ParamScope private (owner: Symbol) extends SourceScope(owner)
+final class ParamScope private (owner: Symbol) extends OutlineScope(owner)
 
 object ParamScope {
   def apply(owner: Symbol): ParamScope = {
@@ -369,7 +369,7 @@ object ParamScope {
   }
 }
 
-final class SelfScope private (owner: Symbol) extends SourceScope(owner)
+final class SelfScope private (owner: Symbol) extends OutlineScope(owner)
 
 object SelfScope {
   def apply(owner: Symbol): SelfScope = {
@@ -377,7 +377,7 @@ object SelfScope {
   }
 }
 
-class TemplateScope protected (sym: Symbol, val tree: DefnTemplate) extends SourceScope(sym) {
+class TemplateScope protected (sym: Symbol, val tree: DefnTemplate) extends OutlineScope(sym) {
   var _parents: List[Scope] = null
   var _self: List[Scope] = null
   var _env: Env = null
@@ -451,7 +451,7 @@ object TemplateScope {
   }
 }
 
-final class TypeParamScope private (owner: Symbol) extends SourceScope(owner)
+final class TypeParamScope private (owner: Symbol) extends OutlineScope(owner)
 
 object TypeParamScope {
   def apply(owner: Symbol): TypeParamScope = {
@@ -459,7 +459,7 @@ object TypeParamScope {
   }
 }
 
-final class ExistentialScope private () extends SourceScope(NoSymbol)
+final class ExistentialScope private () extends OutlineScope(NoSymbol)
 
 object ExistentialScope {
   def apply(): ExistentialScope = {
@@ -467,7 +467,7 @@ object ExistentialScope {
   }
 }
 
-final class RefineScope private () extends SourceScope(NoSymbol)
+final class RefineScope private () extends OutlineScope(NoSymbol)
 
 object RefineScope {
   def apply(): RefineScope = {

--- a/rsc/src/main/scala/rsc/outline/Scopes.scala
+++ b/rsc/src/main/scala/rsc/outline/Scopes.scala
@@ -8,6 +8,7 @@ import rsc.semantics._
 import rsc.syntax._
 import rsc.util._
 import scala.collection.JavaConverters._
+import scala.meta.internal.{semanticdb => s}
 import scala.meta.internal.semanticdb.Scala.{Descriptor => d}
 
 sealed abstract class Scope(val sym: Symbol) extends Work {
@@ -30,7 +31,7 @@ sealed abstract class Scope(val sym: Symbol) extends Work {
 // ============ TWO FOUNDATIONAL SCOPES ============
 
 sealed trait ClasspathScope extends Scope {
-  def classpath: Classpath
+  protected def classpath: Classpath
 
   private val loaded: Map[Name, Symbol] = new LinkedHashMap[Name, Symbol]
   protected def load(name: Name): Symbol = {
@@ -173,7 +174,7 @@ sealed abstract class OutlineScope(sym: Symbol) extends Scope(sym) {
 
 // ============ CLASSPATH SCOPES ============
 
-final class PackageScope private (sym: Symbol, val classpath: Classpath)
+final class PackageScope private (sym: Symbol, protected val classpath: Classpath)
     extends OutlineScope(sym)
     with ClasspathScope {
   override def resolve(name: Name): SymbolResolution = {
@@ -202,9 +203,13 @@ object PackageScope {
   }
 }
 
-final class SignatureScope private (sym: Symbol, val classpath: Classpath)
+final class SignatureScope private (sym: Symbol, protected val classpath: Classpath)
     extends Scope(sym)
     with ClasspathScope {
+  def signature: s.ClassSignature = {
+    classpath(sym).asInstanceOf[s.ClassSignature]
+  }
+
   override def enter(name: Name, sym: Symbol): Symbol = {
     crash(this)
   }

--- a/rsc/src/main/scala/rsc/outline/Scopes.scala
+++ b/rsc/src/main/scala/rsc/outline/Scopes.scala
@@ -5,7 +5,6 @@ package rsc.outline
 import java.util.{LinkedHashMap, Map}
 import rsc.classpath._
 import rsc.semantics._
-import rsc.symtab._
 import rsc.syntax._
 import rsc.util._
 import scala.collection.JavaConverters._
@@ -201,10 +200,6 @@ final class PackageScope private (sym: Symbol, protected val classpath: Classpat
 object PackageScope {
   def apply(sym: Symbol, classpath: Classpath): PackageScope = {
     new PackageScope(sym, classpath)
-  }
-
-  def apply(sym: Symbol, symtab: Symtab): PackageScope = {
-    new PackageScope(sym, symtab.classpath)
   }
 }
 

--- a/rsc/src/main/scala/rsc/outline/Scopes.scala
+++ b/rsc/src/main/scala/rsc/outline/Scopes.scala
@@ -29,7 +29,7 @@ sealed abstract class Scope(val sym: Symbol) extends Work {
 
 // ============ TWO FOUNDATIONAL SCOPES ============
 
-sealed trait BinaryScope extends Scope {
+sealed trait ClasspathScope extends Scope {
   def classpath: Classpath
 
   private val loaded: Map[Name, Symbol] = new LinkedHashMap[Name, Symbol]
@@ -171,11 +171,11 @@ sealed abstract class OutlineScope(sym: Symbol) extends Scope(sym) {
   }
 }
 
-// ============ BINARY SCOPES ============
+// ============ CLASSPATH SCOPES ============
 
 final class PackageScope private (sym: Symbol, val classpath: Classpath)
     extends OutlineScope(sym)
-    with BinaryScope {
+    with ClasspathScope {
   override def resolve(name: Name): SymbolResolution = {
     super.resolve(name) match {
       case MissingResolution =>
@@ -204,7 +204,7 @@ object PackageScope {
 
 final class SignatureScope private (sym: Symbol, val classpath: Classpath)
     extends Scope(sym)
-    with BinaryScope {
+    with ClasspathScope {
   override def enter(name: Name, sym: Symbol): Symbol = {
     crash(this)
   }
@@ -220,7 +220,7 @@ final class SignatureScope private (sym: Symbol, val classpath: Classpath)
 }
 
 object SignatureScope {
-  def apply(sym: Symbol, classpath: Classpath): BinaryScope = {
+  def apply(sym: Symbol, classpath: Classpath): ClasspathScope = {
     new SignatureScope(sym, classpath)
   }
 }

--- a/rsc/src/main/scala/rsc/outline/Scopes.scala
+++ b/rsc/src/main/scala/rsc/outline/Scopes.scala
@@ -173,29 +173,6 @@ sealed abstract class OutlineScope(sym: Symbol) extends Scope(sym) {
 
 // ============ BINARY SCOPES ============
 
-final class ClasspathScope private (sym: Symbol, val classpath: Classpath)
-    extends Scope(sym)
-    with BinaryScope {
-  override def enter(name: Name, sym: Symbol): Symbol = {
-    crash(this)
-  }
-
-  override def resolve(name: Name): SymbolResolution = {
-    load(name) match {
-      case NoSymbol =>
-        MissingResolution
-      case sym =>
-        ResolvedSymbol(sym)
-    }
-  }
-}
-
-object ClasspathScope {
-  def apply(sym: Symbol, classpath: Classpath): BinaryScope = {
-    new ClasspathScope(sym, classpath)
-  }
-}
-
 final class PackageScope private (sym: Symbol, val classpath: Classpath)
     extends OutlineScope(sym)
     with BinaryScope {
@@ -222,6 +199,29 @@ final class PackageScope private (sym: Symbol, val classpath: Classpath)
 object PackageScope {
   def apply(sym: Symbol, classpath: Classpath): PackageScope = {
     new PackageScope(sym, classpath)
+  }
+}
+
+final class SignatureScope private (sym: Symbol, val classpath: Classpath)
+    extends Scope(sym)
+    with BinaryScope {
+  override def enter(name: Name, sym: Symbol): Symbol = {
+    crash(this)
+  }
+
+  override def resolve(name: Name): SymbolResolution = {
+    load(name) match {
+      case NoSymbol =>
+        MissingResolution
+      case sym =>
+        ResolvedSymbol(sym)
+    }
+  }
+}
+
+object SignatureScope {
+  def apply(sym: Symbol, classpath: Classpath): BinaryScope = {
+    new SignatureScope(sym, classpath)
   }
 }
 

--- a/rsc/src/main/scala/rsc/outline/Scopes.scala
+++ b/rsc/src/main/scala/rsc/outline/Scopes.scala
@@ -5,6 +5,7 @@ package rsc.outline
 import java.util.{LinkedHashMap, Map}
 import rsc.classpath._
 import rsc.semantics._
+import rsc.symtab._
 import rsc.syntax._
 import rsc.util._
 import scala.collection.JavaConverters._
@@ -200,6 +201,10 @@ final class PackageScope private (sym: Symbol, protected val classpath: Classpat
 object PackageScope {
   def apply(sym: Symbol, classpath: Classpath): PackageScope = {
     new PackageScope(sym, classpath)
+  }
+
+  def apply(sym: Symbol, symtab: Symtab): PackageScope = {
+    new PackageScope(sym, symtab.classpath)
   }
 }
 

--- a/rsc/src/main/scala/rsc/outline/Synthesizer.scala
+++ b/rsc/src/main/scala/rsc/outline/Synthesizer.scala
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.outline
 
+import rsc.classpath._
 import rsc.gensym._
 import rsc.report._
 import rsc.semantics._
@@ -15,10 +16,11 @@ final class Synthesizer private (
     settings: Settings,
     reporter: Reporter,
     gensyms: Gensyms,
+    classpath: Classpath,
     symtab: Symtab,
     todo: Todo) {
   private lazy val scheduler: Scheduler = {
-    Scheduler(settings, reporter, gensyms, symtab, todo)
+    Scheduler(settings, reporter, gensyms, classpath, symtab, todo)
   }
 
   def caseClassMembers(env: Env, tree: DefnClass): Unit = {
@@ -650,8 +652,9 @@ object Synthesizer {
       settings: Settings,
       reporter: Reporter,
       gensyms: Gensyms,
+      classpath: Classpath,
       symtab: Symtab,
       todo: Todo): Synthesizer = {
-    new Synthesizer(settings, reporter, gensyms, symtab, todo)
+    new Synthesizer(settings, reporter, gensyms, classpath, symtab, todo)
   }
 }

--- a/rsc/src/main/scala/rsc/pretty/PrettyWork.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyWork.scala
@@ -46,7 +46,7 @@ object PrettyWork {
     x match {
       case x: ClasspathScope =>
         p.str(" [...]")
-      case x: SourceScope =>
+      case x: OutlineScope =>
         p.str(" [")
         val symbols = {
           x match {

--- a/rsc/src/main/scala/rsc/pretty/PrettyWork.scala
+++ b/rsc/src/main/scala/rsc/pretty/PrettyWork.scala
@@ -32,7 +32,7 @@ object PrettyWork {
             p.str(" and ")
             p.str(x.parent2.sym)
           }
-        case x: ClasspathScope =>
+        case x: SignatureScope =>
           val info = x.classpath(x.sym)
           p.str(" ")
           p.rep(info.parents ++ info.self, " with ")(sym => p.str(sym))
@@ -44,8 +44,6 @@ object PrettyWork {
       }
     }
     x match {
-      case x: ClasspathScope =>
-        p.str(" [...]")
       case x: OutlineScope =>
         p.str(" [")
         val symbols = {
@@ -56,6 +54,8 @@ object PrettyWork {
         }
         p.rep(symbols, ", ")(p.str)
         p.str("]")
+      case x: SignatureScope =>
+        p.str(" [...]")
       case _ =>
         ()
     }

--- a/rsc/src/main/scala/rsc/semanticdb/Infos.scala
+++ b/rsc/src/main/scala/rsc/semanticdb/Infos.scala
@@ -10,24 +10,24 @@ import rsc.util._
 import scala.meta.internal.{semanticdb => s}
 
 class Infos private (classpathInfos: Classpath) {
-  private val sourceInfos = new HashMap[Symbol, s.SymbolInformation]
-  private val sourcePositions = new HashMap[Symbol, Position]
+  private val outlineInfos = new HashMap[Symbol, s.SymbolInformation]
+  private val outlinePositions = new HashMap[Symbol, Position]
   val staticOwners = new HashSet[Symbol]
 
   def contains(sym: Symbol): Boolean = {
-    sourceInfos.containsKey(sym) ||
+    outlineInfos.containsKey(sym) ||
     classpathInfos.contains(sym)
   }
 
   def apply(sym: Symbol): s.SymbolInformation = {
-    val sourceInfo = sourceInfos.get(sym)
-    if (sourceInfo != null) sourceInfo
+    val outlineInfo = outlineInfos.get(sym)
+    if (outlineInfo != null) outlineInfo
     else classpathInfos(sym)
   }
 
   def pos(sym: Symbol): Position = {
     if (contains(sym)) {
-      val pos = sourcePositions.get(sym)
+      val pos = outlinePositions.get(sym)
       if (pos != null) pos else NoPosition
     } else {
       crash(sym)
@@ -35,8 +35,8 @@ class Infos private (classpathInfos: Classpath) {
   }
 
   def put(sym: Symbol, info: s.SymbolInformation, pos: Position): Unit = {
-    sourceInfos.put(sym, info)
-    sourcePositions.put(sym, pos)
+    outlineInfos.put(sym, info)
+    outlinePositions.put(sym, pos)
     if (info.isStatic) {
       staticOwners.add(sym.owner)
       staticOwners.add(sym.owner.companionObject)

--- a/rsc/src/main/scala/rsc/semanticdb/Prefixes.scala
+++ b/rsc/src/main/scala/rsc/semanticdb/Prefixes.scala
@@ -98,17 +98,10 @@ trait Prefixes {
               case d.Term("package") =>
                 qualSym != ownerSym.owner
               case _ =>
-                val outline = symtab.outlines.get(id.sym)
-                outline match {
-                  case Some(outline) =>
-                    !outline.hasStatic
-                  case _ =>
-                    if (symtab.classpath.contains(id.sym)) {
-                      val info = symtab.classpath(id.sym)
-                      !info.isStatic
-                    } else {
-                      false
-                    }
+                symtab.metadata(id.sym) match {
+                  case OutlineMetadata(outline) => !outline.hasStatic
+                  case ClasspathMetadata(info) => !info.isStatic
+                  case NoMetadata => false
                 }
             }
           } else {

--- a/rsc/src/main/scala/rsc/semanticdb/Scopes.scala
+++ b/rsc/src/main/scala/rsc/semanticdb/Scopes.scala
@@ -10,7 +10,7 @@ import scala.meta.internal.{semanticdb => s}
 trait Scopes {
   self: Converter =>
 
-  protected implicit class SourceScopeOps(scope: SourceScope) {
+  protected implicit class OutlineScopeOps(scope: OutlineScope) {
     def scope(linkMode: LinkMode): Some[s.Scope] = {
       val outlines = scope.decls.flatMap(_.asMulti).map(symtab.outlines.apply)
       val eligibles = scope match {
@@ -21,7 +21,7 @@ trait Scopes {
     }
   }
 
-  protected implicit class OutlineScopeOps(outlines: List[Outline]) {
+  protected implicit class PseudoScopeOps(outlines: List[Outline]) {
     def scope(linkMode: LinkMode): Some[s.Scope] = {
       linkMode match {
         case SymlinkChildren => Some(s.Scope(symlinks = outlines.map(_.id.sym)))

--- a/rsc/src/main/scala/rsc/semanticdb/Templates.scala
+++ b/rsc/src/main/scala/rsc/semanticdb/Templates.scala
@@ -70,8 +70,8 @@ trait Templates {
             rscParents match {
               case List(TptParameterize(_, targs), _*) =>
                 val tparams = {
-                  val isSource = symtab.scopes(scalacFirstParentSym).isInstanceOf[SourceScope]
-                  if (isSource) {
+                  val isOutline = symtab.scopes(scalacFirstParentSym).isInstanceOf[OutlineScope]
+                  if (isOutline) {
                     val outline = symtab.outlines(scalacFirstParentSym)
                     outline.asInstanceOf[Parameterized].tparams.map(_.id.sym)
                   } else {

--- a/rsc/src/main/scala/rsc/semanticdb/Templates.scala
+++ b/rsc/src/main/scala/rsc/semanticdb/Templates.scala
@@ -39,7 +39,7 @@ trait Templates {
                     case tree =>
                       crash(tree)
                   }
-                case ResolvedScope(firstResolution: BinaryScope) =>
+                case ResolvedScope(firstResolution: ClasspathScope) =>
                   val firstInfo = symtab.classpath.apply(firstParentSym)
                   if (firstInfo.isTrait || firstInfo.isInterface) {
                     normalizeFirstParentSym(firstInfo.parents.head)

--- a/rsc/src/main/scala/rsc/semanticdb/Templates.scala
+++ b/rsc/src/main/scala/rsc/semanticdb/Templates.scala
@@ -70,13 +70,10 @@ trait Templates {
             rscParents match {
               case List(TptParameterize(_, targs), _*) =>
                 val tparams = {
-                  val isOutline = symtab.scopes(scalacFirstParentSym).isInstanceOf[OutlineScope]
-                  if (isOutline) {
-                    val outline = symtab.outlines(scalacFirstParentSym)
-                    outline.asInstanceOf[Parameterized].tparams.map(_.id.sym)
-                  } else {
-                    val sig = symtab.classpath.apply(scalacFirstParentSym).signature
-                    sig.asInstanceOf[s.ClassSignature].typeParameters.symbols
+                  symtab.metadata(scalacFirstParentSym) match {
+                    case OutlineMetadata(outline: Parameterized) => outline.tparams.map(_.id.sym)
+                    case ClasspathMetadata(info) => info.tparams
+                    case _ => crash(scalacFirstParentSym)
                   }
                 }
                 if (tparams.nonEmpty) TptParameterize(id, targs)

--- a/rsc/src/main/scala/rsc/semantics/Metadata.scala
+++ b/rsc/src/main/scala/rsc/semantics/Metadata.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2017-2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.semantics
+
+import rsc.syntax._
+import scala.meta.internal.{semanticdb => s}
+
+sealed trait Metadata
+case class OutlineMetadata(outline: Outline) extends Metadata
+case class ClasspathMetadata(info: s.SymbolInformation) extends Metadata
+case object NoMetadata extends Metadata

--- a/rsc/src/main/scala/rsc/symtab/Scopes.scala
+++ b/rsc/src/main/scala/rsc/symtab/Scopes.scala
@@ -13,14 +13,14 @@ import scala.meta.internal.{semanticdb => s}
 trait Scopes {
   def classpath: Classpath
 
-  private val sourceScopes = new HashMap[Symbol, Scope]
+  private val outlineScopes = new HashMap[Symbol, Scope]
   private val classpathScopes = new HashMap[Symbol, Scope]
   private val existentialScopes = new HashMap[TptExistential, ExistentialScope]
   private val refineScopes = new HashMap[TptRefine, RefineScope]
 
   object scopes {
     def apply(sym: Symbol): Scope = {
-      val scope1 = sourceScopes.get(sym)
+      val scope1 = outlineScopes.get(sym)
       if (scope1 != null) return scope1
       val scope2 = classpathScopes.get(sym)
       if (scope2 != null) return scope2
@@ -42,7 +42,7 @@ trait Scopes {
     }
 
     def contains(sym: Symbol): Boolean = {
-      sourceScopes.containsKey(sym) ||
+      outlineScopes.containsKey(sym) ||
       classpathScopes.containsKey(sym) ||
       tryLoadClasspathScope(sym) != null
     }
@@ -56,12 +56,12 @@ trait Scopes {
     }
 
     def put(sym: Symbol, scope: Scope): Unit = {
-      if (sourceScopes.containsKey(sym)) {
+      if (outlineScopes.containsKey(sym)) {
         crash(sym)
       }
       sym match {
         case NoSymbol => crash(scope)
-        case other => sourceScopes.put(other, scope)
+        case other => outlineScopes.put(other, scope)
       }
     }
 

--- a/rsc/src/main/scala/rsc/symtab/Scopes.scala
+++ b/rsc/src/main/scala/rsc/symtab/Scopes.scala
@@ -11,7 +11,7 @@ import rsc.util._
 import scala.meta.internal.{semanticdb => s}
 
 trait Scopes {
-  def classpath: Classpath
+  protected def classpath: Classpath
 
   private val outlineScopes = new HashMap[Symbol, Scope]
   private val classpathScopes = new HashMap[Symbol, Scope]

--- a/rsc/src/main/scala/rsc/symtab/Scopes.scala
+++ b/rsc/src/main/scala/rsc/symtab/Scopes.scala
@@ -84,7 +84,7 @@ trait Scopes {
         val info = classpath.apply(sym)
         val scope = info.signature match {
           case s.NoSignature if info.isPackage => PackageScope(sym, classpath)
-          case _: s.ClassSignature => ClasspathScope(sym, classpath)
+          case _: s.ClassSignature => SignatureScope(sym, classpath)
           case _ => return null
         }
         scope.succeed()

--- a/rsc/src/main/scala/rsc/symtab/Services.scala
+++ b/rsc/src/main/scala/rsc/symtab/Services.scala
@@ -2,91 +2,10 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.symtab
 
-import java.util.HashMap
-import rsc.input._
-import rsc.outline._
 import rsc.semantics._
-import rsc.syntax._
-import rsc.util._
-import scala.meta.internal.{semanticdb => s}
 
 trait Services {
   self: Symtab =>
-
-  private val scopifies = new HashMap[Symbol, Scope]
-
-  def scopify(sym: Symbol): ScopeResolution = {
-    if (scopes.contains(sym)) {
-      ResolvedScope(scopes(sym))
-    } else {
-      val scope = scopifies.get(sym)
-      if (scope != null) {
-        ResolvedScope(scope)
-      } else {
-        metadata(sym) match {
-          case OutlineMetadata(outline) =>
-            def loop(tpt: Tpt): ScopeResolution = {
-              tpt match {
-                case TptArray(_) =>
-                  loop(TptId("Array").withSym(ArrayClass))
-                case TptApply(fun, _) =>
-                  loop(fun)
-                case tpt: TptPath =>
-                  tpt.id.sym match {
-                    case NoSymbol =>
-                      BlockedResolution(Unknown())
-                    case sym =>
-                      scopify(sym)
-                  }
-                case TptWildcardExistential(_, tpt) =>
-                  loop(tpt)
-                case _ =>
-                  crash(tpt)
-              }
-            }
-            outline match {
-              case DefnMethod(mods, _, _, _, Some(tpt), _) if mods.hasVal => loop(tpt)
-              case outline: DefnType => loop(outline.desugaredUbound)
-              case outline: TypeParam => loop(outline.desugaredUbound)
-              case Param(_, _, Some(tpt), _) => loop(tpt)
-              case Self(_, Some(tpt)) => loop(tpt)
-              case outline @ Self(_, None) => loop(desugars.rets(outline))
-              case null => crash(sym)
-              case _ => crash(outline)
-            }
-          case ClasspathMetadata(info) =>
-            def loop(tpe: s.Type): Symbol = {
-              tpe match {
-                case s.TypeRef(_, sym, _) => sym
-                case s.SingleType(_, sym) => sym
-                case _ => crash(tpe.asMessage.toProtoString)
-              }
-            }
-            val scopeSym = {
-              if (sym == "scala/collection/convert/package.wrapAsScala.") {
-                // FIXME: https://github.com/twitter/rsc/issues/285
-                "scala/collection/convert/WrapAsScala#"
-              } else {
-                info.signature match {
-                  case s.NoSignature if info.isPackage => sym
-                  case _: s.ClassSignature => sym
-                  case sig: s.MethodSignature if info.isVal => loop(sig.returnType)
-                  case sig: s.TypeSignature => loop(sig.upperBound)
-                  case sig: s.ValueSignature => loop(sig.tpe)
-                  case sig => crash(info.toProtoString)
-                }
-              }
-            }
-            val scope = SignatureScope(scopeSym, classpath)
-            scope.succeed()
-            scopifies.put(sym, scope)
-            ResolvedScope(scope)
-          case NoMetadata =>
-            MissingResolution
-        }
-      }
-    }
-  }
 
   def metadata(sym: Symbol): Metadata = {
     if (outlines.contains(sym)) {
@@ -96,17 +15,6 @@ trait Services {
         ClasspathMetadata(classpath(sym))
       } else {
         NoMetadata
-      }
-    }
-  }
-
-  private implicit class BoundedScopifyOps(bounded: Bounded) {
-    def desugaredUbound: Tpt = {
-      bounded.lang match {
-        case ScalaLanguage | UnknownLanguage =>
-          bounded.ubound.getOrElse(TptId("Any").withSym(AnyClass))
-        case JavaLanguage =>
-          bounded.ubound.getOrElse(TptId("Object").withSym(ObjectClass))
       }
     }
   }

--- a/rsc/src/main/scala/rsc/symtab/Services.scala
+++ b/rsc/src/main/scala/rsc/symtab/Services.scala
@@ -62,7 +62,6 @@ trait Services {
                 case _ => crash(tpe.asMessage.toProtoString)
               }
             }
-            val info = classpath.apply(sym)
             val scopeSym = {
               if (sym == "scala/collection/convert/package.wrapAsScala.") {
                 // FIXME: https://github.com/twitter/rsc/issues/285

--- a/rsc/src/main/scala/rsc/symtab/Services.scala
+++ b/rsc/src/main/scala/rsc/symtab/Services.scala
@@ -80,7 +80,7 @@ trait Services {
                   }
                 }
               }
-              val scope = ClasspathScope(scopeSym, classpath)
+              val scope = SignatureScope(scopeSym, classpath)
               scope.succeed()
               scopifies.put(sym, scope)
               ResolvedScope(scope)

--- a/rsc/src/main/scala/rsc/symtab/Symtab.scala
+++ b/rsc/src/main/scala/rsc/symtab/Symtab.scala
@@ -4,7 +4,7 @@ package rsc.symtab
 
 import rsc.classpath._
 
-final class Symtab private (val classpath: Classpath)
+final class Symtab private (protected val classpath: Classpath)
     extends AutoCloseable
     with Desugars
     with Envs

--- a/rsc/src/main/scala/rsc/symtab/Symtab.scala
+++ b/rsc/src/main/scala/rsc/symtab/Symtab.scala
@@ -5,14 +5,11 @@ package rsc.symtab
 import rsc.classpath._
 
 final class Symtab private (protected val classpath: Classpath)
-    extends AutoCloseable
-    with Desugars
+    extends Desugars
     with Envs
     with Outlines
     with Scopes
-    with Services {
-  def close(): Unit = classpath.close()
-}
+    with Services
 
 object Symtab {
   def apply(classpath: Classpath): Symtab = {

--- a/rsc/src/main/scala/rsc/util/SemanticdbUtil.scala
+++ b/rsc/src/main/scala/rsc/util/SemanticdbUtil.scala
@@ -32,5 +32,13 @@ trait SemanticdbUtil {
       case _ =>
         Nil
     }
+
+    def tparams: List[String] = info.signature match {
+      case sig: ClassSignature => sig.typeParameters.symbols
+      case sig: MethodSignature => sig.typeParameters.symbols
+      case sig: TypeSignature => sig.typeParameters.symbols
+      case sig: ValueSignature => Nil
+      case NoSignature => Nil
+    }
   }
 }


### PR DESCRIPTION
This pull request finishes refactoring of the Symtab API that was started in #299:
  * I introduced Symtab.metadata which provides a unified interface to symbol metadata.
  * That allowed to rewrite normalizeFirstParentSym without scopify (which fixed #267).
  * In turn, that allowed to demote Symtab.scopify to a private method in Outliner. 
  * I also demoted Symtab.classpath to a protected val. Now Classpath has to be passed around explicitly.