### PR TITLE
Partial support for super accessors (fix #100)

### DIFF
--- a/examples/dependencies/src/main/scala/100.scala
+++ b/examples/dependencies/src/main/scala/100.scala
@@ -1,0 +1,15 @@
+package ticket100
+
+trait T1 {
+  def x: Int = ???
+}
+
+trait T2 extends T1 {
+  private def super$x(self: T1): Int = ???
+  def y: Int = super.x
+}
+
+trait HasRemoteInfo extends Exception {
+  private def super$getMessage(self: java.lang.Throwable)(): String = ???
+  def exceptionMessage(): String = super.getMessage()
+}

--- a/examples/semantic/src/main/scala/100.scala
+++ b/examples/semantic/src/main/scala/100.scala
@@ -1,0 +1,5 @@
+package ticket100
+
+class C extends T2
+
+class E extends Exception with HasRemoteInfo


### PR DESCRIPTION
While working on #100, I realized that we're in trouble.

In order to generate super accessors, a Scala compiler needs to go through method bodies, typecheck super selections and see which of them qualify. At the moment, Rsc doesn't look into method bodies at all, which looks like a game over.

All's not lost, however. Since super accessors are pretty exotic, our users may be willing to accept additional notational overhead to express them. A workaround along these lines has been implemented in this pull request. For example, let's look at #100:

```scala
trait T1 {
  def x: Int = ???
}

trait T2 extends T1 {
  def y: Int = super.x
}
```

```
13:31 ~/Projects/2126/sandbox (HEAD)$ s -Xprint:refchecks
[[syntax trees at end of                 refchecks]] // Test.scala
package <empty> {
  abstract trait T1 extends scala.AnyRef {
    def /*T1*/$init$(): Unit = {
      ()
    };
    def x: Int = scala.Predef.???
  };
  abstract trait T2 extends AnyRef with T1 {
    <superaccessor> <artifact> private def super$x: Int;
    def /*T2*/$init$(): Unit = {
      ()
    };
    def y: Int = T2.this.super$x
  }
}
```

In order to nudge Rsc into generating a ScalaSignature entry for `super$x`, we can adopt the following notation (due to some reason, Scalac needs to know which base class the superaccessor is referring to, and we encode that in an additional parameter section):

```scala
trait T1 {
  def x: Int = ???
}

trait T2 extends T1 {
  private def super$x(self: T1): Int = ???
  def y: Int = super.x
}
```

I've explored a prettier notation for the same thing: `private def super$x: Int = super[T1].x`, but unfortunately it doesn't work when the type in brackets is a class (due to some reason, Scalac says "implementation restriction: traits may not select fields or methods from super[C] where C is a class").