### PR TITLE
Upgrade to Scalameta 4.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val V = new {
   val asm = "6.0"
   val scala = computeScalaVersionFromTravisYml("2.11")
   val scalafix = computeScalafixVersionFromBinScalafix()
-  val scalameta = "4.1.0"
+  val scalameta = "4.1.1"
   val scalatest = "3.0.5"
 }
 


### PR DESCRIPTION
/cc @baroquebobcat @cosmicexplorer @WiWa (this takes care of https://github.com/scalameta/scalameta/pull/1820 which was crashing Metacp on some of the recent 3rdparty dependencies).