### PR TITLE
Cache member lookup in RscCompat Scopes

### DIFF
--- a/scalafix/rules/src/main/scala/rsc/rules/semantics/Scopes.scala
+++ b/scalafix/rules/src/main/scala/rsc/rules/semantics/Scopes.scala
@@ -3,6 +3,7 @@
 package rsc.rules.semantics
 
 import rsc.rules.semantics.Scope.MemberKey
+import rsc.rules.util.memoize
 import scala.collection.mutable
 import scala.meta._
 import scala.meta.internal.{semanticdb => s}
@@ -15,12 +16,10 @@ sealed trait Scope {
 
   def getRename(name: n.Name): String = ""
 
-  private val _cache = new java.util.HashMap[MemberKey, String]
-
   protected def member(symtab: Symtab, sym: String, name: n.Name): String =
-    _cache.computeIfAbsent(MemberKey(symtab, sym, name), _member)
+    _member(MemberKey(symtab, sym, name))
 
-  private def _member(key: MemberKey): String = {
+  private val _member: MemberKey => String = memoize { key: MemberKey =>
     val MemberKey(symtab, sym, name) = key
 
     def getInfo(desc: Descriptor): Option[s.SymbolInformation] =

--- a/scalafix/rules/src/main/scala/rsc/rules/semantics/Scopes.scala
+++ b/scalafix/rules/src/main/scala/rsc/rules/semantics/Scopes.scala
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.rules.semantics
 
-import rsc.rules.semantics.Scope.MemberKey
 import rsc.rules.util.memoize
 import scala.collection.mutable
 import scala.meta._
@@ -12,6 +11,8 @@ import scala.meta.internal.semanticdb.Scala.{Descriptor => d}
 import scala.meta.internal.semanticdb.Scala.{Names => n}
 
 sealed trait Scope {
+  import Scope.MemberKey
+
   def lookup(name: n.Name): String
 
   def getRename(name: n.Name): String = ""
@@ -35,7 +36,7 @@ sealed trait Scope {
   }
 }
 object Scope {
-  final case class MemberKey(symtab: Symtab, sym: String, name: n.Name)
+  private[Scope] final case class MemberKey(symtab: Symtab, sym: String, name: n.Name)
 }
 
 final class AddedImportsScope extends Scope {

--- a/scalafix/rules/src/main/scala/rsc/rules/util/MemoizeUtil.scala
+++ b/scalafix/rules/src/main/scala/rsc/rules/util/MemoizeUtil.scala
@@ -1,0 +1,14 @@
+package rsc.rules.util
+
+trait MemoizeUtil {
+
+  /**
+   * Memoize the results of a function call to prevent repeated calls
+   */
+  def memoize[I, O](f: I => O): I => O = {
+    val _cache = new java.util.HashMap[I, O]
+
+    key =>
+      _cache.computeIfAbsent(key, _ => f(key))
+  }
+}

--- a/scalafix/rules/src/main/scala/rsc/rules/util/package.scala
+++ b/scalafix/rules/src/main/scala/rsc/rules/util/package.scala
@@ -1,0 +1,3 @@
+package rsc.rules
+
+package object util extends MemoizeUtil


### PR DESCRIPTION
Without this, it seems RscCompat is too slow with `better = true`.