### PR TITLE
Better checkscalasig

### DIFF
--- a/check/src/main/scala/rsc/checkscalasig/Main.scala
+++ b/check/src/main/scala/rsc/checkscalasig/Main.scala
@@ -2,12 +2,17 @@ package rsc.checkscalasig
 
 import java.nio.file.Path
 import _root_.rsc.checkbase.{SimpleBase, ToolResult}
+import rsc.checkscalasig.Settings.ClassFiles
 
 /**
  * Example invocation (in sbt):
  * check/runMain rsc.checkscalasig.Main --classpath $JAVALIB:SCALALIB C.scala
  *
  * Replace $JAVALIB:SCALALIB with the actual paths
+ *
+ * Or in --classfiles mode to check output
+ *
+ * check/runMain rsc.checkscalasig.Main --classfiles rsc_output.jar nsc_output.jar
  */
 object Main extends SimpleBase[Settings, Path, Path] {
 
@@ -16,11 +21,11 @@ object Main extends SimpleBase[Settings, Path, Path] {
   }
 
   def nscResult(settings: Settings): ToolResult[Path] = {
-    nsc(settings.cp, settings.ins)
+    settings.classfiles.nsc.map(Right(_)).getOrElse(nsc(settings.cp, settings.ins))
   }
 
   def rscResult(settings: Settings): ToolResult[Path] = {
-    rsc(settings.cp, settings.ins)
+    settings.classfiles.rsc.map(Right(_)).getOrElse(rsc(settings.cp, settings.ins))
   }
 
   def checker(settings: Settings, nscResult: Path, rscResult: Path): Checker = {

--- a/check/src/main/scala/rsc/checkscalasig/Main.scala
+++ b/check/src/main/scala/rsc/checkscalasig/Main.scala
@@ -2,7 +2,6 @@ package rsc.checkscalasig
 
 import java.nio.file.Path
 import _root_.rsc.checkbase.{SimpleBase, ToolResult}
-import rsc.checkscalasig.Settings.ClassFiles
 
 /**
  * Example invocation (in sbt):

--- a/check/src/main/scala/rsc/checkscalasig/Settings.scala
+++ b/check/src/main/scala/rsc/checkscalasig/Settings.scala
@@ -3,19 +3,19 @@ package rsc.checkscalasig
 import java.io.File.pathSeparator
 import java.nio.file.{Path, Paths}
 import rsc.checkbase.SettingsBase
-import rsc.checkscalasig.Settings.ClassFiles
+import rsc.checkscalasig.Settings.ClassfilesPath
 
 final case class Settings(
     cp: List[Path] = Nil,
     ins: List[Path] = Nil,
     quiet: Boolean = false,
     saveOutput: Boolean = false,
-    classfiles: ClassFiles = ClassFiles(None, None)
+    classfiles: ClassfilesPath = ClassfilesPath(None, None)
 ) extends SettingsBase
 
 object Settings {
 
-  final case class ClassFiles(rsc: Option[Path], nsc: Option[Path])
+  final case class ClassfilesPath(rsc: Option[Path], nsc: Option[Path])
 
   private def pathsFor(pathStr: String): List[Path] =
     pathStr.split(pathSeparator).map(s => Paths.get(s)).toList
@@ -31,7 +31,10 @@ object Settings {
         case "--classfiles" +: rsc_path +: nsc_path +: Nil =>
           val rsc_files = Paths.get(rsc_path)
           val nsc_files = Paths.get(nsc_path)
-          loop(settings.copy(classfiles = ClassFiles(Some(rsc_files), Some(nsc_files))), true, Nil)
+          loop(
+            settings.copy(classfiles = ClassfilesPath(Some(rsc_files), Some(nsc_files))),
+            true,
+            Nil)
         case "--classpath" +: s_cp +: rest if allowOptions =>
           val cp = pathsFor(s_cp)
           loop(settings.copy(cp = settings.cp ++ cp), true, rest)

--- a/check/src/main/scala/rsc/checkscalasig/Settings.scala
+++ b/check/src/main/scala/rsc/checkscalasig/Settings.scala
@@ -3,15 +3,23 @@ package rsc.checkscalasig
 import java.io.File.pathSeparator
 import java.nio.file.{Path, Paths}
 import rsc.checkbase.SettingsBase
+import rsc.checkscalasig.Settings.ClassFiles
 
 final case class Settings(
     cp: List[Path] = Nil,
     ins: List[Path] = Nil,
     quiet: Boolean = false,
-    saveOutput: Boolean = false
+    saveOutput: Boolean = false,
+    classfiles: ClassFiles = ClassFiles(None, None)
 ) extends SettingsBase
 
 object Settings {
+
+  final case class ClassFiles(rsc: Option[Path], nsc: Option[Path])
+
+  private def pathsFor(pathStr: String): List[Path] =
+    pathStr.split(pathSeparator).map(s => Paths.get(s)).toList
+
   def parse(args: List[String]): Either[List[String], Settings] = {
     def loop(
         settings: Settings,
@@ -20,8 +28,12 @@ object Settings {
       args match {
         case "--" +: rest =>
           loop(settings, false, rest)
+        case "--classfiles" +: rsc_path +: nsc_path +: Nil =>
+          val rsc_files = Paths.get(rsc_path)
+          val nsc_files = Paths.get(nsc_path)
+          loop(settings.copy(classfiles = ClassFiles(Some(rsc_files), Some(nsc_files))), true, Nil)
         case "--classpath" +: s_cp +: rest if allowOptions =>
-          val cp = s_cp.split(pathSeparator).map(s => Paths.get(s)).toList
+          val cp = pathsFor(s_cp)
           loop(settings.copy(cp = settings.cp ++ cp), true, rest)
         case "--save-output" +: rest if allowOptions =>
           loop(settings.copy(saveOutput = true), true, rest)


### PR DESCRIPTION
Allow the checker to take in already-compiled classfiles and also split the diffing by top-level symbol. 