### PR TITLE
Add ability to take in multiple classfiles for checkscalasig

### DIFF
--- a/check/src/main/scala/rsc/checkscalasig/Checker.scala
+++ b/check/src/main/scala/rsc/checkscalasig/Checker.scala
@@ -11,10 +11,10 @@ import scala.meta.scalasig.highlevel._
  * Checks *high-level* scalasigs
  *
  * @param settings
- * @param nscResult Scalac-produced classfile with scalasigs
- * @param rscResult Rsc-produced classfile with scalasigs
+ * @param nscResults Scalac-produced classfiles with scalasigs
+ * @param rscResults Rsc-produced classfiles with scalasigs
  */
-class Checker(settings: Settings, nscResult: Path, rscResult: Path)
+class Checker(settings: Settings, nscResults: List[Path], rscResults: List[Path])
     extends CheckerBase
     with DiffUtil {
 
@@ -33,8 +33,8 @@ class Checker(settings: Settings, nscResult: Path, rscResult: Path)
 
   def check(): Unit = {
 
-    val nscSigs = Scalasigs.list(nscResult).flatMap(resultSyms).toMap
-    val rscSigs = Scalasigs.list(rscResult).flatMap(resultSyms).toMap
+    val nscSigs = Scalasigs.list(nscResults: _*).flatMap(resultSyms).toMap
+    val rscSigs = Scalasigs.list(rscResults: _*).flatMap(resultSyms).toMap
 
     assert(nscSigs.keySet == rscSigs.keySet)
 

--- a/check/src/main/scala/rsc/checkscalasig/Main.scala
+++ b/check/src/main/scala/rsc/checkscalasig/Main.scala
@@ -13,21 +13,21 @@ import _root_.rsc.checkbase.{SimpleBase, ToolResult}
  *
  * check/runMain rsc.checkscalasig.Main --classfiles rsc_output.jar nsc_output.jar
  */
-object Main extends SimpleBase[Settings, Path, Path] {
+object Main extends SimpleBase[Settings, List[Path], List[Path]] {
 
   def settings(args: List[String]): Either[List[String], Settings] = {
     Settings.parse(args)
   }
 
-  def nscResult(settings: Settings): ToolResult[Path] = {
-    settings.classfiles.nsc.map(Right(_)).getOrElse(nsc(settings.cp, settings.ins))
+  def nscResult(settings: Settings): ToolResult[List[Path]] = {
+    settings.classfiles.nsc.map(Right(_)).getOrElse(nsc(settings.cp, settings.ins).map(List(_)))
   }
 
-  def rscResult(settings: Settings): ToolResult[Path] = {
-    settings.classfiles.rsc.map(Right(_)).getOrElse(rsc(settings.cp, settings.ins))
+  def rscResult(settings: Settings): ToolResult[List[Path]] = {
+    settings.classfiles.rsc.map(Right(_)).getOrElse(rsc(settings.cp, settings.ins).map(List(_)))
   }
 
-  def checker(settings: Settings, nscResult: Path, rscResult: Path): Checker = {
-    new Checker(settings, nscResult, rscResult)
+  def checker(settings: Settings, nscResults: List[Path], rscResults: List[Path]): Checker = {
+    new Checker(settings, nscResults, rscResults)
   }
 }

--- a/check/src/main/scala/rsc/checkscalasig/Settings.scala
+++ b/check/src/main/scala/rsc/checkscalasig/Settings.scala
@@ -15,7 +15,7 @@ final case class Settings(
 
 object Settings {
 
-  final case class ClassfilesPath(rsc: Option[Path], nsc: Option[Path])
+  final case class ClassfilesPath(rsc: Option[List[Path]], nsc: Option[List[Path]])
 
   private def pathsFor(pathStr: String): List[Path] =
     pathStr.split(pathSeparator).map(s => Paths.get(s)).toList
@@ -29,8 +29,8 @@ object Settings {
         case "--" +: rest =>
           loop(settings, false, rest)
         case "--classfiles" +: rsc_path +: nsc_path +: Nil =>
-          val rsc_files = Paths.get(rsc_path)
-          val nsc_files = Paths.get(nsc_path)
+          val rsc_files = pathsFor(rsc_path)
+          val nsc_files = pathsFor(nsc_path)
           loop(
             settings.copy(classfiles = ClassfilesPath(Some(rsc_files), Some(nsc_files))),
             true,


### PR DESCRIPTION
If users have a bunch of classfiles or jars they wish to check, should be able to source scalasigs from all of them at once.