### PR TITLE
checkbytecode should be able to run on pre-compiled jars

### DIFF
--- a/check/src/main/scala/rsc/checkbase/SettingsBase.scala
+++ b/check/src/main/scala/rsc/checkbase/SettingsBase.scala
@@ -2,6 +2,16 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.checkbase
 
+import java.io.File.pathSeparator
+import java.nio.file.{Path, Paths}
+
 trait SettingsBase {
   def quiet: Boolean
+}
+object SettingsBase {
+
+  final case class ClassfilesPath(rsc: Option[List[Path]], nsc: Option[List[Path]])
+
+  def pathsFor(pathStr: String): List[Path] =
+    pathStr.split(pathSeparator).map(s => Paths.get(s)).toList
 }

--- a/check/src/main/scala/rsc/checkbytecode/Checker.scala
+++ b/check/src/main/scala/rsc/checkbytecode/Checker.scala
@@ -8,10 +8,13 @@ import java.nio.file._
 import rsc.checkbase._
 import scala.tools.jardiff._
 
-class Checker(nscResult: Path, rscResult: Path) extends CheckerBase {
+class Checker(
+    nscResults: List[Path],
+    rscResults: List[Path]
+) extends CheckerBase {
   def check(): Unit = {
     val baos = new ByteArrayOutputStream()
-    val paths = List(List(nscResult), List(rscResult))
+    val paths = List(nscResults, rscResults)
     val config = JarDiff.Config(
       gitRepo = None,
       code = true,

--- a/check/src/main/scala/rsc/checkbytecode/Main.scala
+++ b/check/src/main/scala/rsc/checkbytecode/Main.scala
@@ -5,22 +5,30 @@ package rsc.checkbytecode
 import java.nio.file._
 import rsc.checkbase._
 
-object Main extends SimpleBase[Settings, Path, Path] {
-  def settings(args: List[String]) = {
+object Main extends SimpleBase[Settings, List[Path], List[Path]] {
+  def settings(args: List[String]): Either[List[String], Settings] = {
     Settings.parse(args)
   }
 
-  def nscResult(settings: Settings) = {
+  private def compileNscResult(settings: Settings): ToolResult[Path] = {
     val nscJars = nscs(settings.cp, settings.deps :+ settings.ins)
     nscJars.right.flatMap(nscJars => Right(nscJars.last))
   }
 
-  def rscResult(settings: Settings) = {
+  private def compileRscResult(settings: Settings): ToolResult[Path] = {
     val rscJars = rscs(settings.cp, settings.deps)
     rscJars.right.flatMap(rscJars => nsc(settings.cp ++ rscJars, settings.ins))
   }
 
-  def checker(settings: Settings, nscResult: Path, rscResult: Path) = {
-    new Checker(nscResult, rscResult)
+  def nscResult(settings: Settings): ToolResult[List[Path]] = {
+    settings.precomputedJars.nsc.map(Right(_)).getOrElse(compileNscResult(settings).map(List(_)))
+  }
+
+  def rscResult(settings: Settings): ToolResult[List[Path]] = {
+    settings.precomputedJars.rsc.map(Right(_)).getOrElse(compileRscResult(settings).map(List(_)))
+  }
+
+  def checker(settings: Settings, nscResults: List[Path], rscResults: List[Path]): Checker = {
+    new Checker(nscResults, rscResults)
   }
 }

--- a/check/src/main/scala/rsc/checkscalasig/Settings.scala
+++ b/check/src/main/scala/rsc/checkscalasig/Settings.scala
@@ -1,9 +1,8 @@
 package rsc.checkscalasig
 
-import java.io.File.pathSeparator
 import java.nio.file.{Path, Paths}
 import rsc.checkbase.SettingsBase
-import rsc.checkscalasig.Settings.ClassfilesPath
+import rsc.checkbase.SettingsBase.ClassfilesPath
 
 final case class Settings(
     cp: List[Path] = Nil,
@@ -14,12 +13,6 @@ final case class Settings(
 ) extends SettingsBase
 
 object Settings {
-
-  final case class ClassfilesPath(rsc: Option[List[Path]], nsc: Option[List[Path]])
-
-  private def pathsFor(pathStr: String): List[Path] =
-    pathStr.split(pathSeparator).map(s => Paths.get(s)).toList
-
   def parse(args: List[String]): Either[List[String], Settings] = {
     def loop(
         settings: Settings,
@@ -29,14 +22,14 @@ object Settings {
         case "--" +: rest =>
           loop(settings, false, rest)
         case "--classfiles" +: rsc_path +: nsc_path +: Nil =>
-          val rsc_files = pathsFor(rsc_path)
-          val nsc_files = pathsFor(nsc_path)
+          val rsc_files = SettingsBase.pathsFor(rsc_path)
+          val nsc_files = SettingsBase.pathsFor(nsc_path)
           loop(
             settings.copy(classfiles = ClassfilesPath(Some(rsc_files), Some(nsc_files))),
             true,
             Nil)
         case "--classpath" +: s_cp +: rest if allowOptions =>
-          val cp = pathsFor(s_cp)
+          val cp = SettingsBase.pathsFor(s_cp)
           loop(settings.copy(cp = settings.cp ++ cp), true, rest)
         case "--save-output" +: rest if allowOptions =>
           loop(settings.copy(saveOutput = true), true, rest)


### PR DESCRIPTION
The checkbytecode CLI should accept jars to diff rather than requiring compilation steps in the tool itself.