### PR TITLE
Fix parenthesization of ascribed function types with single tuple arg

### DIFF
--- a/scalafix/input/src/main/scala/rsc/tests/BetterRscCompat.scala
+++ b/scalafix/input/src/main/scala/rsc/tests/BetterRscCompat.scala
@@ -283,4 +283,11 @@ object BetterRscCompat_Test {
 
     class H extends V
   }
+
+  object FunctionTypes {
+
+    val f1 = (_: (Int, Int)) => ()
+
+    def f2 = (_: (Int, Int), _: Int) => ()
+  }
 }

--- a/scalafix/output/src/main/scala/rsc/tests/BetterRscCompat.scala
+++ b/scalafix/output/src/main/scala/rsc/tests/BetterRscCompat.scala
@@ -283,4 +283,11 @@ object BetterRscCompat_Test {
 
     class H extends V
   }
+
+  object FunctionTypes {
+
+    val f1: ((Int, Int)) => Unit = (_: (Int, Int)) => ()
+
+    def f2: ((Int, Int), Int) => Unit = (_: (Int, Int), _: Int) => ()
+  }
 }

--- a/scalafix/rules/src/main/scala/rsc/rules/pretty/SemanticdbPrinter.scala
+++ b/scalafix/rules/src/main/scala/rsc/rules/pretty/SemanticdbPrinter.scala
@@ -30,13 +30,22 @@ class SemanticdbPrinter(
             rep(args, ", ")(normal)
             str(")")
           } else if (sym.startsWith("scala/Function")) {
-            var params :+ ret = args
+            val params :+ ret = args
             val hasByNameArg = params.exists(_.isInstanceOf[s.ByNameType])
             val hasFunctionArg = params.exists {
               case s.TypeRef(pre, sym, args) if sym.startsWith("scala/Function") => true
               case _ => false
             }
-            val needsExtraParens = hasFunctionArg || hasByNameArg || (params.length != 1)
+            val singleTupleArg = params.length == 1 && (params.head match {
+              case s.TypeRef(_, argSym, _) => argSym.startsWith("scala/Tuple")
+              case _ => false
+            })
+
+            val needsExtraParens = hasFunctionArg ||
+              hasByNameArg ||
+              singleTupleArg ||
+              (params.length != 1)
+
             if (needsExtraParens) str("(")
             rep(params, ", ") { normal }
             if (needsExtraParens) str(")")


### PR DESCRIPTION
`val foo = (t: (A, B)) => ()` should be ascribed `foo: ((A, B)) => Unit` instead of `foo: (A, B) => Unit`, i.e. extra parentheses are necessary when dealing with functions of a single tuple argument.