### PR TITLE
Remove type refinements from ascribed structural types

### DIFF
--- a/scalafix/output/src/main/scala/rsc/tests/BetterRscCompat.scala
+++ b/scalafix/output/src/main/scala/rsc/tests/BetterRscCompat.scala
@@ -146,7 +146,7 @@ object BetterRscCompat_Test {
       val bar: Int = 1
     }
 
-    val t3: Trait2 { def foo: Int } = new Trait2 {
+    val t3: Trait2 = new Trait2 {
       def foo: Int = 1
       val bar: Int = 1
     }

--- a/scalafix/rules/src/main/scala/rsc/rules/pretty/SemanticdbPrinter.scala
+++ b/scalafix/rules/src/main/scala/rsc/rules/pretty/SemanticdbPrinter.scala
@@ -134,12 +134,14 @@ class SemanticdbPrinter(
         case s.StructuralType(utpe, decls) =>
           decls.infos.foreach(symbols.append)
           opt(utpe)(normal)
-          if (decls.infos.nonEmpty) {
-            rep(" { ", decls.infos, "; ", " }")(pprint)
-          } else {
-            utpe match {
-              case s.WithType(tpes) if tpes.length > 1 => ()
-              case _ => str(" {}")
+          if (!config.better) {
+            if (decls.infos.nonEmpty) {
+              rep(" { ", decls.infos, "; ", " }")(pprint)
+            } else {
+              utpe match {
+                case s.WithType(tpes) if tpes.length > 1 => ()
+                case _ => str(" {}")
+              }
             }
           }
         case s.AnnotatedType(anns, utpe) =>


### PR DESCRIPTION
Structural type ascriptions are a pretty bad pattern, so let's not ascribe them in a rewrite. Furthermore, this will prevent a strange bug where `scalac` would say that the `found` and `required` types are not the same, while the printed type strings are equivalent.